### PR TITLE
Create test harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,5 @@ svg-animations.js: web-animations.js smil-in-javascript.js
 clean:
 	rm -f svg-animations.js smil-in-javascript-4lint.js
 
-lint: smil-in-javascript.js
+lint: smil-in-javascript.js test/harness.js
 	./run-lint.sh

--- a/run-lint.sh
+++ b/run-lint.sh
@@ -15,5 +15,5 @@ fi
 # Comment out the (function() {} ) wrapper
 sed -e'17s-^-//-' -e'$s-^-//-' smil-in-javascript.js > smil-in-javascript-4lint.js
 
-gjslint --summary --nojsdoc smil-in-javascript-4lint.js && rm smil-in-javascript-4lint.js
+gjslint --summary --nojsdoc smil-in-javascript-4lint.js test/harness.js && rm smil-in-javascript-4lint.js
 exit $?

--- a/smil-in-javascript.js
+++ b/smil-in-javascript.js
@@ -162,6 +162,7 @@ function createAnimation(animationRecord) {
 
     // FIXME: Respect begin and end attributes.
     animationRecord.player = document.timeline.play(animation);
+    animationRecord.player.startTime = 0;
   }
 }
 
@@ -322,8 +323,7 @@ function walkSVG(node) {
   }
 }
 
-window.onload = function() {
-
+window.addEventListener('load', function() {
   // We would like to use document.querySelectorAll(tag) for each tag in
   // observedTags, but can't yet due to
   // querySelectorAll unable to find SVG camelCase elements in HTML
@@ -333,6 +333,6 @@ window.onload = function() {
   for (var index = 0; index < svgFragmentList.length; ++index) {
     walkSVG(svgFragmentList[index]);
   }
-};
+});
 
 })();

--- a/test/harness.js
+++ b/test/harness.js
@@ -1,0 +1,115 @@
+/**
+ * Copyright 2014 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+'use strict';
+
+function timing_test_impl(callback, desc) {
+  console.log('RUNNING: ' + desc);
+  var svgFragmentList = document.querySelectorAll('svg');
+
+  var expectationList = [];
+  var expectationIndex = -1;
+
+  var numExpectationMatches = 0;
+
+  // Control debug logging.
+  var verbose = false;
+
+  function setTime(millis) {
+    for (var fragmentIndex = 0;
+         fragmentIndex < svgFragmentList.length;
+         ++fragmentIndex) {
+      svgFragmentList[fragmentIndex].pauseAnimations();
+      svgFragmentList[fragmentIndex].setCurrentTime(millis / 1000);
+    }
+    document.timeline._pauseAnimationsForTesting(millis);
+  }
+
+  function verifyExpectation() {
+    var expectation = expectationList[expectationIndex];
+    var expectedValue = expectation.expectedValue;
+
+    // FIXME: getAttribute(expectation.propertyName) does not return
+    // animated value for polyfillAnimatedElement but does for
+    // nativeAnimatedElement.
+    var polyfillAnimatedValue = expectation.polyfillAnimatedElement.
+        attributes[expectation.propertyName].value;
+    var nativeAnimatedValue = expectation.nativeAnimatedElement.
+        attributes[expectation.propertyName].value;
+
+    var matched = false;
+    if (Array.isArray(expectedValue)) {
+      if (expectedValue.indexOf(polyfillAnimatedValue) > -1 &&
+          expectedValue.indexOf(nativeAnimatedValue) > -1) {
+        matched = true;
+      }
+    } else {
+      if (polyfillAnimatedValue === expectedValue.toString() &&
+          nativeAnimatedValue === expectedValue.toString()) {
+        matched = true;
+      }
+    }
+
+    if (verbose || !matched) {
+      console.log(expectation.millis + 'ms ' + expectation.propertyName +
+          ' expected=' + expectedValue +
+          ' polyfill=' + polyfillAnimatedValue +
+          ' native=' + nativeAnimatedValue + '.');
+    }
+
+    if (matched) {
+      ++numExpectationMatches;
+    }
+    scheduleNext();
+  }
+
+  function scheduleNext() {
+    ++expectationIndex;
+    if (expectationIndex < expectationList.length) {
+      var expectation = expectationList[expectationIndex];
+      setTime(expectation.millis);
+      window.requestAnimationFrame(verifyExpectation);
+    } else if (numExpectationMatches === expectationList.length) {
+      console.log('PASSED: ' + desc);
+    } else {
+      console.log('FAILED: ' + desc);
+    }
+  }
+
+  var original_at = window.at;
+  window.at = function(millis, propertyName, expectedValue,
+                       polyfillAnimatedElement, nativeAnimatedElement) {
+    expectationList.push({
+      millis: millis,
+      propertyName: propertyName,
+      expectedValue: expectedValue,
+      polyfillAnimatedElement: polyfillAnimatedElement,
+      nativeAnimatedElement: nativeAnimatedElement
+    });
+  };
+  callback();
+  window.at = original_at;
+
+  scheduleNext();
+}
+
+// FIXME: support a sequence of timing tests.
+// For now, timing_test may only be called once.
+function timing_test(callback, desc) {
+  window.addEventListener('load', function() {
+    timing_test_impl(callback, desc);
+  });
+}

--- a/test/testcases/animate-check.js
+++ b/test/testcases/animate-check.js
@@ -1,0 +1,10 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillRect = document.getElementById('polyfillRect');
+  var nativeRect = document.getElementById('nativeRect');
+
+  at(0, 'width', 200, polyfillRect, nativeRect);
+  at(1500, 'width', 50, polyfillRect, nativeRect);
+  at(2500, 'width', 150, polyfillRect, nativeRect);
+}, 'animate width');

--- a/test/testcases/animate.html
+++ b/test/testcases/animate.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="animate-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="250">
+  <rect id="polyfillRect" x="0" y="0" width="100" height="100" fill="green">
+    <animate attributeName="width" from="200" to="0" dur="2s" repeatCount="indefinite"/>
+  </rect>
+
+  <rect id="nativeRect" x="0" y="110" width="100" height="100" fill="green">
+    <nativeAnimate attributeName="width" from="200" to="0" dur="2s" repeatCount="indefinite"/>
+  </rect>
+</svg>
+
+  </body>
+</html>

--- a/test/testcases/animateTransform-check.js
+++ b/test/testcases/animateTransform-check.js
@@ -1,0 +1,14 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillRect = document.getElementById('polyfillRect');
+  var nativeRect = document.getElementById('nativeRect');
+
+  at(0, 'transform', ['scale(1)', 'scale(1 1)'], polyfillRect, nativeRect);
+  at(500, 'transform', ['scale(1.5)', 'scale(1.5 1.5)'], polyfillRect, nativeRect);
+  at(1000, 'transform', ['scale(2)', 'scale(2 2)'], polyfillRect, nativeRect);
+  at(1500, 'transform', ['scale(2.5)', 'scale(2.5 2.5)'], polyfillRect, nativeRect);
+  // FIXME: final transform for polyfillRect should be '', not 'null'.
+  at(2500, 'transform', ['null', ''], polyfillRect, nativeRect);
+
+}, 'animateTransform scale');

--- a/test/testcases/animateTransform.html
+++ b/test/testcases/animateTransform.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="animateTransform-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="500">
+  <rect id="polyfillRect" width="40" height="40" fill="green">
+    <animateTransform attributeName="transform" type="scale" from="1" to="3" dur="2s"/>
+  </rect>
+
+  <rect id="nativeRect" x="130" width="40" height="40" fill="green">
+    <nativeAnimateTransform attributeName="transform" type="scale" from="1" to="3" dur="2s"/>
+  </rect>
+</svg>
+
+  </body>
+</html>

--- a/test/testcases/set-check.js
+++ b/test/testcases/set-check.js
@@ -1,0 +1,9 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillRect = document.getElementById('polyfillRect');
+  var nativeRect = document.getElementById('nativeRect');
+
+  at(0, 'width', 200, polyfillRect, nativeRect);
+  at(10000, 'width', 200, polyfillRect, nativeRect);
+}, 'set width');

--- a/test/testcases/set.html
+++ b/test/testcases/set.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="set-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="250">
+  <rect id="polyfillRect" x="0" y="0" width="100" height="100" fill="green">
+    <set attributeName="width" to="200"/>
+  </rect>
+
+  <rect id="nativeRect" x="0" y="110" width="100" height="100" fill="green">
+    <nativeSet attributeName="width" to="200"/>
+  </rect>
+</svg>
+
+  </body>
+</html>


### PR DESCRIPTION
Add a simple test harness for running layout tests.

Currently, the tests are run manually by opening test pages in the browser and checking the console for PASSED or FAILED reports.

Initial tests exercise the following animation element types: animate, animateTransform and set.

We create an animation using the Polyfill implementation, and another
using the native implementation, and verify property expectations at a
sequence of times.
