### PR TITLE
Simple animation tests

### DIFF
--- a/test/harness.js
+++ b/test/harness.js
@@ -66,8 +66,10 @@ function timing_test_impl(callback, desc) {
     if (verbose || !matched) {
       console.log(expectation.millis + 'ms ' + expectation.propertyName +
           ' expected=' + expectedValue +
-          ' polyfill=' + polyfillAnimatedValue +
-          ' native=' + nativeAnimatedValue + '.');
+          ' ' + expectation.polyfillAnimatedElement.id +
+          '=' + polyfillAnimatedValue +
+          ' ' + expectation.nativeAnimatedElement.id +
+          '=' + nativeAnimatedValue + '.');
     }
 
     if (matched) {

--- a/test/testcases/circle-check.js
+++ b/test/testcases/circle-check.js
@@ -1,0 +1,14 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillCircle = document.getElementById('polyfillCircle');
+  var nativeCircle = document.getElementById('nativeCircle');
+
+  at(0, 'cx', 300, polyfillCircle, nativeCircle);
+  at(1000, 'cy', 275, polyfillCircle, nativeCircle);
+  at(2000, 'r', 150, polyfillCircle, nativeCircle);
+  at(3000, 'cx', 225, polyfillCircle, nativeCircle);
+  at(4000, 'cy', 200, polyfillCircle, nativeCircle);
+  at(5000, 'r', 100, polyfillCircle, nativeCircle);
+
+}, 'animate circle');

--- a/test/testcases/circle.html
+++ b/test/testcases/circle.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="circle-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="600" height="600">
+  <circle id="polyfillCircle" cx="20" cy="20" r="10" fill="green" opacity="0.5">
+    <animate attributeName="cx" from="300" to="200" dur="4s" fill="freeze"/>
+    <animate attributeName="cy" from="300" to="200" dur="4s" fill="freeze"/>
+    <animate attributeName="r" from="200" to="100" dur="4s" fill="freeze"/>
+  </circle>
+
+  <circle id="nativeCircle" cx="20" cy="20" r="10" fill="red" opacity="0.5">
+    <nativeAnimate attributeName="cx" from="300" to="200" dur="4s" fill="freeze"/>
+    <nativeAnimate attributeName="cy" from="300" to="200" dur="4s" fill="freeze"/>
+    <nativeAnimate attributeName="r" from="200" to="100" dur="4s" fill="freeze"/>
+  </circle>
+</svg>
+
+  </body>
+</html>

--- a/test/testcases/clock-values-check.js
+++ b/test/testcases/clock-values-check.js
@@ -1,0 +1,36 @@
+'use strict';
+
+timing_test(function() {
+  var firstPolyfillRect = document.getElementById('firstPolyfillRect');
+  var secondPolyfillRect = document.getElementById('secondPolyfillRect');
+  var thirdPolyfillRect = document.getElementById('thirdPolyfillRect');
+  var fourthPolyfillRect = document.getElementById('fourthPolyfillRect');
+  var fifthPolyfillRect = document.getElementById('fifthPolyfillRect');
+  var sixthPolyfillRect = document.getElementById('sixthPolyfillRect');
+  var seventhPolyfillRect = document.getElementById('seventhPolyfillRect');
+  var eighthPolyfillRect = document.getElementById('eighthPolyfillRect');
+  var ninthPolyfillRect = document.getElementById('ninthPolyfillRect');
+  var tenthPolyfillRect = document.getElementById('tenthPolyfillRect');
+
+  var firstNativeRect = document.getElementById('firstNativeRect');
+  var secondNativeRect = document.getElementById('secondNativeRect');
+  var thirdNativeRect = document.getElementById('thirdNativeRect');
+  var fourthNativeRect = document.getElementById('fourthNativeRect');
+  var fifthNativeRect = document.getElementById('fifthNativeRect');
+  var sixthNativeRect = document.getElementById('sixthNativeRect');
+  var seventhNativeRect = document.getElementById('seventhNativeRect');
+  var eighthNativeRect = document.getElementById('eighthNativeRect');
+  var ninthNativeRect = document.getElementById('ninthNativeRect');
+  var tenthNativeRect = document.getElementById('tenthNativeRect');
+
+  at(1000, 'height', 300, firstPolyfillRect, firstNativeRect);
+  at(1000, 'height', 300, secondPolyfillRect, secondNativeRect);
+  at(1000, 'height', 300, thirdPolyfillRect, thirdNativeRect);
+  at(1000, 'height', 300, fourthPolyfillRect, fourthNativeRect);
+  at(1000, 'height', 300, fifthPolyfillRect, fifthNativeRect);
+  at(1000, 'height', 300, sixthPolyfillRect, sixthNativeRect);
+  at(1000, 'height', 300, seventhPolyfillRect, seventhNativeRect);
+  at(1000, 'height', 300, eighthPolyfillRect, eighthNativeRect);
+  at(1000, 'height', 100, ninthPolyfillRect, ninthNativeRect);
+  at(1000, 'height', 100, tenthPolyfillRect, tenthNativeRect);
+}, 'clock values for duration');

--- a/test/testcases/clock-values.html
+++ b/test/testcases/clock-values.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="clock-values-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="500" height="500">
+  <rect id="firstPolyfillRect" x="0" y="0" width="40" height="100" fill="green" opacity="0.5">
+    <animate id="firstAnimation" attributeName="height" from="100" to="1440100" dur="2h"/>
+  </rect>
+  <rect id="secondPolyfillRect" x="50" y="0" width="40" height="100" fill="green" opacity="0.5">
+    <animate id="secondAnimation" attributeName="height" from="100" to="24100" dur="2min"/>
+  </rect>
+  <rect id="thirdPolyfillRect" x="100" y="0" width="40" height="100" fill="green" opacity="0.5">
+    <animate id="thirdAnimation" attributeName="height" from="100" to="6100" dur="30"/> <!-- seconds implicitly -->
+  </rect>
+  <rect id="fourthPolyfillRect" x="150" y="0" width="40" height="100" fill="green" opacity="0.5">
+    <animate id="fourthAnimation" attributeName="height" from="100" to="1630" dur="7650ms"/>
+  </rect>
+  <rect id="fifthPolyfillRect" x="200" y="0" width="40" height="100" fill="green" opacity="0.5">
+    <animate id="fifthAnimation" attributeName="height" from="100" to="24750" dur="02:03.250"/>
+  </rect>
+  <rect id="sixthPolyfillRect" x="250" y="0" width="40" height="100" fill="green" opacity="0.5">
+    <animate id="sixthAnimation" attributeName="height" from="100" to="1477000" dur="2:03:04.500"/>
+  </rect>
+  <rect id="seventhPolyfillRect" x="300" y="0" width="40" height="100" fill="green" opacity="0.5">
+    <animate id="seventhAnimation" attributeName="height" from="100" to="1400" dur="00:06.500"/>
+  </rect>
+  <rect id="eighthPolyfillRect" x="350" y="0" width="40" height="100" fill="green" opacity="0.5">
+    <animate id="eighthAnimation" attributeName="height" from="100" to="1550" dur="0:00:07.250"/>
+  </rect>
+  <rect id="ninthPolyfillRect" x="400" y="0" width="40" height="100" fill="green" opacity="0.5">
+    <animate id="ninthAnimation" attributeName="height" from="100" to="999999" dur="indefinite"/>
+  </rect>
+  <rect id="tenthPolyfillRect" x="450" y="0" width="40" height="100" fill="green" opacity="0.5">
+    <animate id="tenthAnimation" attributeName="height" from="100" to="999999"/> <!-- indefinite duration, implicitly -->
+  </rect>
+
+  <rect id="firstNativeRect" x="0" y="0" width="40" height="100" fill="red" opacity="0.5">
+    <nativeAnimate id="firstAnimation" attributeName="height" from="100" to="1440100" dur="2h"/>
+  </rect>
+  <rect id="secondNativeRect" x="50" y="0" width="40" height="100" fill="red" opacity="0.5">
+    <nativeAnimate id="secondAnimation" attributeName="height" from="100" to="24100" dur="2min"/>
+  </rect>
+  <rect id="thirdNativeRect" x="100" y="0" width="40" height="100" fill="red" opacity="0.5">
+    <nativeAnimate id="thirdAnimation" attributeName="height" from="100" to="6100" dur="30"/> <!-- seconds implicitly -->
+  </rect>
+  <rect id="fourthNativeRect" x="150" y="0" width="40" height="100" fill="red" opacity="0.5">
+    <nativeAnimate id="fourthAnimation" attributeName="height" from="100" to="1630" dur="7650ms"/>
+  </rect>
+  <rect id="fifthNativeRect" x="200" y="0" width="40" height="100" fill="red" opacity="0.5">
+    <nativeAnimate id="fifthAnimation" attributeName="height" from="100" to="24750" dur="02:03.250"/>
+  </rect>
+  <rect id="sixthNativeRect" x="250" y="0" width="40" height="100" fill="red" opacity="0.5">
+    <!-- Chrome doesn't support dur 2:03:04.500, Firefox does -->
+    <nativeAnimate id="sixthAnimation" attributeName="height" from="100" to="1477000" dur="7384.5s"/>
+  </rect>
+  <rect id="seventhNativeRect" x="300" y="0" width="40" height="100" fill="red" opacity="0.5">
+    <nativeAnimate id="seventhAnimation" attributeName="height" from="100" to="1400" dur="00:06.500"/>
+  </rect>
+  <rect id="eighthNativeRect" x="350" y="0" width="40" height="100" fill="red" opacity="0.5">
+    <!-- Chrome doesn't support dur 0:00:07.250, Firefox does -->
+    <nativeAnimate id="eighthAnimation" attributeName="height" from="100" to="1550" dur="00:07.250"/>
+  </rect>
+  <rect id="ninthNativeRect" x="400" y="0" width="40" height="100" fill="red" opacity="0.5">
+    <nativeAnimate id="ninthAnimation" attributeName="height" from="100" to="999999" dur="indefinite"/>
+  </rect>
+  <rect id="tenthNativeRect" x="450" y="0" width="40" height="100" fill="red" opacity="0.5">
+    <nativeAnimate id="tenthAnimation" attributeName="height" from="100" to="999999"/> <!-- indefinite duration, implicitly -->
+  </rect>
+</svg>
+
+  </body>
+</html>

--- a/test/testcases/color-check.js
+++ b/test/testcases/color-check.js
@@ -1,0 +1,13 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillRect = document.getElementById('polyfillRect');
+  var nativeRect = document.getElementById('nativeRect');
+
+  // FIXME: understand why native animation is always reporting fill as green
+  at(0, 'fill', ['rgba(0, 0, 0, 1)', 'green'], polyfillRect, nativeRect);
+  at(500, 'fill', ['rgba(64, 0, 0, 1)', 'green'], polyfillRect, nativeRect);
+  at(1000, 'fill', ['rgba(128, 0, 0, 1)', 'green'], polyfillRect, nativeRect);
+  at(1500, 'fill', ['rgba(191, 0, 0, 1)', 'green'], polyfillRect, nativeRect);
+  at(2500, 'fill', 'green', polyfillRect, nativeRect);
+}, 'animate fill');

--- a/test/testcases/color.html
+++ b/test/testcases/color.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="color-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="250">
+  <rect id="polyfillRect" x="0" y="0" width="100" height="100" fill="green">
+    <animate attributeName="fill" from="black" to="red" dur="2s"/>
+  </rect>
+
+  <rect id="nativeRect" x="0" y="110" width="100" height="100" fill="green">
+    <nativeAnimate attributeName="fill" from="black" to="red" dur="2s"/>
+  </rect>
+</svg>
+
+  </body>
+</html>

--- a/test/testcases/freeze-check.js
+++ b/test/testcases/freeze-check.js
@@ -1,0 +1,19 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillRect = document.getElementById('polyfillRect');
+  var nativeRect = document.getElementById('nativeRect');
+
+  // FIXME: enable width tests when Polyfill implements support for begin time(s).
+  // (width animation should begin after 2s, not immediately)
+  at(0, 'x', 100, polyfillRect, nativeRect);
+  at(500, 'height', 125, polyfillRect, nativeRect);
+  // at(1000, 'width', 100, polyfillRect, nativeRect);
+  at(1500, 'x', 175, polyfillRect, nativeRect);
+  at(2000, 'height', 200, polyfillRect, nativeRect);
+  // at(2500, 'width', 125, polyfillRect, nativeRect);
+  at(3000, 'x', 200, polyfillRect, nativeRect);
+  at(3500, 'height', 200, polyfillRect, nativeRect);
+  at(4000, 'width', 200, polyfillRect, nativeRect);
+
+}, 'freeze animated values');

--- a/test/testcases/freeze.html
+++ b/test/testcases/freeze.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="freeze-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="600" height="600">
+  <rect id="polyfillRect" x="100" y="100" width="100" height="100" fill="green" opacity="0.5">
+    <animate attributeName="x" from="100" to="200" dur="2s" fill="freeze"/>
+    <animate attributeName="height" from="100" to="200" dur="2s" fill="freeze"/>
+    <animate attributeName="width" from="100" to="200" begin="2s" dur="2s" fill="freeze"/>
+  </rect>
+
+  <rect id="nativeRect" x="100" y="100" width="100" height="100" fill="red" opacity="0.5">
+    <nativeAnimate attributeName="x" from="100" to="200" dur="2s" fill="freeze"/>
+    <nativeAnimate attributeName="height" from="100" to="200" dur="2s" fill="freeze"/>
+    <nativeAnimate attributeName="width" from="100" to="200" begin="2s" dur="2s" fill="freeze"/>
+  </rect>
+</svg>
+
+  </body>
+</html>

--- a/test/testcases/values-check.js
+++ b/test/testcases/values-check.js
@@ -1,0 +1,25 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillRect = document.getElementById('polyfillRect');
+  var nativeRect = document.getElementById('nativeRect');
+
+  at(0, 'width', 100, polyfillRect, nativeRect);
+  at(250, 'width', 50, polyfillRect, nativeRect);
+  at(500, 'width', 0, polyfillRect, nativeRect);
+  at(750, 'width', 25, polyfillRect, nativeRect);
+  at(1000, 'width', 50, polyfillRect, nativeRect);
+  at(1250, 'width', 25, polyfillRect, nativeRect);
+  at(1500, 'width', 0, polyfillRect, nativeRect);
+  at(1750, 'width', 50, polyfillRect, nativeRect);
+  at(2000, 'width', 100, polyfillRect, nativeRect);
+  at(2250, 'width', 50, polyfillRect, nativeRect);
+  at(2500, 'width', 0, polyfillRect, nativeRect);
+  at(2750, 'width', 25, polyfillRect, nativeRect);
+  at(3000, 'width', 50, polyfillRect, nativeRect);
+  at(3250, 'width', 25, polyfillRect, nativeRect);
+  at(3500, 'width', 0, polyfillRect, nativeRect);
+  at(3750, 'width', 50, polyfillRect, nativeRect);
+  at(4000, 'width', 100, polyfillRect, nativeRect);
+  at(4250, 'width', 100, polyfillRect, nativeRect);
+}, 'value list interpolation');

--- a/test/testcases/values.html
+++ b/test/testcases/values.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="values-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="250">
+  <rect id="polyfillRect" x="0" y="0" width="100" height="100" fill="green">
+    <animate attributeName="width" values="100;0;50;0;100" dur="2s" repeatCount="2"/>
+  </rect>
+
+  <rect id="nativeRect" x="0" y="110" width="100" height="100" fill="green">
+    <nativeAnimate attributeName="width" values="100;0;50;0;100" dur="2s" repeatCount="2"/>
+  </rect>
+</svg>
+
+  </body>
+</html>

--- a/test/testcases/xlink-href-check.js
+++ b/test/testcases/xlink-href-check.js
@@ -1,0 +1,9 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillRect = document.getElementById('polyfillRect');
+  var nativeRect = document.getElementById('nativeRect');
+
+  at(0, 'width', 200, polyfillRect, nativeRect);
+  at(10000, 'width', 200, polyfillRect, nativeRect);
+}, 'set xlink:href width');

--- a/test/testcases/xlink-href.html
+++ b/test/testcases/xlink-href.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="xlink-href-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="250">
+  <rect id="polyfillRect" x="0" y="0" width="100" height="100" fill="green">
+  </rect>
+  <set xlink:href="#polyfillRect" attributeName="width" to="200"/>
+
+  <rect id="nativeRect" x="0" y="110" width="100" height="100" fill="green">
+  </rect>
+  <nativeSet xlink:href="#nativeRect" attributeName="width" to="200"/>
+</svg>
+
+  </body>
+</html>


### PR DESCRIPTION
Add a test that xlink:href can be used to specify the animated element.

Also add several other animation tests from https://github.com/ericwilligers/svg-animation.

We create an animation using the Polyfill implementation, and another using the native implementation, and verify property expectations at a sequence of times.

Unfortunately, the animated value of the fill property isn't being reported for the natively animated element, only for the element animated using the SMIL Polyfill. We animate the fill value in color.html and attempt to test in color-check.js (With the other properties being animated, this problem isn't occurring.)
