### PR TITLE
Allow for mpath element without animateMotion parent

### DIFF
--- a/smil-in-javascript.js
+++ b/smil-in-javascript.js
@@ -150,6 +150,14 @@ function createEffectOptions(animationRecord) {
     // default behavior is options.iterationComposite = 'replace';
   }
 
+  // http://www.w3.org/TR/SVG/animate.html#AnimateMotionElement
+  if (animationRecord.rotate &&
+      animationRecord.rotate === 'auto') {
+    options.autoRotate = 'auto-rotate';
+  } else {
+    // default behavior is options.autoRotate = 'none';
+  }
+
   return options;
 }
 
@@ -262,6 +270,9 @@ function createMotionPathAnimation(animationRecord) {
 
   if (verbose) {
     console.log('resolvedPath = ' + resolvedPath);
+    console.log('options  = ' + JSON.stringify(animationRecord.options));
+    console.log('timingInput  = ' + JSON.stringify(
+        animationRecord.timingInput));
   }
 
   if (resolvedPath) {
@@ -301,7 +312,10 @@ function createAnimationRecord(element) {
   animationRecords[element] = animationRecord;
 
   if (animationRecord.nodeName === 'mpath') {
-    animationRecords[element.parentNode].mpathRecord = animationRecord;
+    var parentRecord = animationRecords[element.parentNode];
+    if (parentRecord) {
+      parentRecord.mpathRecord = animationRecord;
+    }
   } else if (animationRecord.nodeName !== 'animateMotion') {
     createKeyframeAnimation(animationRecord);
   }

--- a/test/testcases/orphan-mpath.html
+++ b/test/testcases/orphan-mpath.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="500">
+  <rect width="40" height="40" fill="green" opacity="0.5">
+    <animateMotion calcMode="linear" dur="2s" repeatCount="indefinite"
+      path="M 100 100 L 300 50"/>
+  </rect>
+  <rect width="40" height="40" fill="red" opacity="0.5">
+    <nativeAnimateMotion calcMode="linear" dur="2s" repeatCount="indefinite"
+      path="M 100 100 L 300 50"/>
+  </rect>
+
+  <!-- This mpath element has no animateMotion parent. -->
+  <mpath xlink:href="#shortPath"/>
+  <path id="shortPath" d="M 1 2 L 3 4"/>
+</svg>
+
+  </body>
+</html>


### PR DESCRIPTION
We were previously setting the mpathRecord member of undefined, when we assigned to
  animationRecords[element.parentNode].mpathRecord
without checking that element.parentNode was present in animationRecords.

We were assuming that the parent element of an mpath element would be an animateMotion element, and therefore already in animationRecords. This is the only context in which mpath is useful, but we shouldn't make assumptions about the SVG we will encounter.
