### PR TITLE
getSimpleDuration and friends

### DIFF
--- a/test/testcases/get-current-time-check.js
+++ b/test/testcases/get-current-time-check.js
@@ -1,0 +1,12 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillRect = document.getElementById('polyfillRect');
+  var nativeRect = document.getElementById('nativeRect');
+  var polyfillAnimation = document.getElementById('polyfillAnimation');
+  var nativeAnimation = document.getElementById('nativeAnimation');
+
+  at(0, 'currentTime', 0, polyfillAnimation, nativeAnimation);
+  at(1800, 'currentTime', 1.8, polyfillAnimation, nativeAnimation);
+  at(3800, 'currentTime', 3.8, polyfillAnimation, nativeAnimation);
+}, 'getCurrentTime');

--- a/test/testcases/get-current-time.html
+++ b/test/testcases/get-current-time.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="get-current-time-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="500">
+  <rect id="polyfillRect" x="10" y="10" width="100" height="100" fill="lime"/>
+  <rect id="nativeRect" x="10" y="10" width="100" height="100" fill="lime"/>
+  <animateMotion id="polyfillAnimation" xlink:href="#polyfillRect" additive="sum" calcMode="linear" path="M 0 0 L 0 100" dur="3s"/>
+  <nativeAnimateMotion id="nativeAnimation" xlink:href="#nativeRect" additive="sum" calcMode="linear" path="M 0 300 L 0 400" dur="3s"/>
+</svg>
+
+  </body>
+</html>

--- a/test/testcases/get-simple-duration-check.js
+++ b/test/testcases/get-simple-duration-check.js
@@ -1,0 +1,13 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillRect = document.getElementById('polyfillRect');
+  var nativeRect = document.getElementById('nativeRect');
+  var polyfillAnimation = document.getElementById('polyfillAnimation');
+  var nativeAnimation = document.getElementById('nativeAnimation');
+
+  at(1400, 'simpleDuration', 3, polyfillAnimation, nativeAnimation);
+  at(3400, 'simpleDuration', 3, polyfillAnimation, nativeAnimation);
+}, 'getSimpleDuration');
+
+// FIXME: Add test where dur has changed.

--- a/test/testcases/get-simple-duration.html
+++ b/test/testcases/get-simple-duration.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="get-simple-duration-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="500">
+  <rect id="polyfillRect" x="10" y="10" width="100" height="100" fill="lime"/>
+  <rect id="nativeRect" x="10" y="10" width="100" height="100" fill="lime"/>
+  <animateMotion id="polyfillAnimation" xlink:href="#polyfillRect" additive="sum" calcMode="linear" path="M 0 0 L 0 100" dur="3s" repeatCount="2"/>
+  <nativeAnimateMotion id="nativeAnimation" xlink:href="#nativeRect" additive="sum" calcMode="linear" path="M 0 300 L 0 400" dur="3s" repeatCount="2"/>
+</svg>
+
+  </body>
+</html>

--- a/test/testcases/get-start-time-check.js
+++ b/test/testcases/get-start-time-check.js
@@ -1,0 +1,14 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillRect = document.getElementById('polyfillRect');
+  var nativeRect = document.getElementById('nativeRect');
+  var polyfillAnimation = document.getElementById('polyfillAnimation');
+  var nativeAnimation = document.getElementById('nativeAnimation');
+
+  at(1600, 'startTime', 0, polyfillAnimation, nativeAnimation);
+}, 'getStartTime');
+
+// FIXME: add test where the animation has not started yet.
+
+// FIXME: add test where the animation has completed.

--- a/test/testcases/get-start-time.html
+++ b/test/testcases/get-start-time.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="get-start-time-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="500">
+  <rect id="polyfillRect" x="10" y="10" width="100" height="100" fill="lime"/>
+  <rect id="nativeRect" x="10" y="10" width="100" height="100" fill="lime"/>
+  <animateMotion id="polyfillAnimation" xlink:href="#polyfillRect" additive="sum" calcMode="linear" path="M 0 0 L 0 100" dur="3s"/>
+  <nativeAnimateMotion id="nativeAnimation" xlink:href="#nativeRect" additive="sum" calcMode="linear" path="M 0 300 L 0 400" dur="3s"/>
+</svg>
+
+  </body>
+</html>

--- a/test/testcases/get-target-element-check.js
+++ b/test/testcases/get-target-element-check.js
@@ -1,0 +1,19 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillRect = document.getElementById('polyfillRect');
+  var nativeRect = document.getElementById('nativeRect');
+  var polyfillAnimation = document.getElementById('polyfillAnimation');
+  var nativeAnimation = document.getElementById('nativeAnimation');
+
+  at(1200, 'targetElement', [polyfillRect, nativeRect], polyfillAnimation, nativeAnimation);
+  at(3200, 'targetElement', [polyfillRect, nativeRect], polyfillAnimation, nativeAnimation);
+}, 'targetElement');
+
+// FIXME: add test where the element with target id is deleted, and replaced by a new element.
+
+// FIXME: add test where the xlink:href attribute is changed.
+
+// FIXME: add test where the xlink:href attribute is deleted.
+
+// FIXME: add test where the xlink:href attribute is added.

--- a/test/testcases/get-target-element.html
+++ b/test/testcases/get-target-element.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="get-target-element-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="500">
+  <rect id="polyfillRect" x="10" y="10" width="100" height="100" fill="lime"/>
+  <rect id="nativeRect" x="10" y="10" width="100" height="100" fill="lime"/>
+  <animateMotion id="polyfillAnimation" xlink:href="#polyfillRect" additive="sum" calcMode="linear" path="M 0 0 L 0 100" dur="3s"/>
+  <nativeAnimateMotion id="nativeAnimation" xlink:href="#nativeRect" additive="sum" calcMode="linear" path="M 0 300 L 0 400" dur="3s"/>
+</svg>
+
+  </body>
+</html>

--- a/web-animations.js
+++ b/web-animations.js
@@ -288,6 +288,15 @@ AnimationTimeline.prototype = {
       player.pause();
       player.currentTime = pauseAt;
     });
+
+    delete this.currentTime;
+    Object.defineProperty(this, 'currentTime', {
+      configurable: true,
+      enumerable: true,
+      get: function() {
+        return pauseAt;
+      }
+    });
   }
 };
 


### PR DESCRIPTION
Add the following to AnimationElement prototype:-
- targetElement property
- getSimpleDuration()
- getCurrentTime()
- getStartTime()

These are defined on SVG animation elements, even if the onload event
has not fired yet.

All duration and time values returned are in seconds.

To support testing of getCurrentTime, we modify the Web Animations polyfill so that, after _pauseAnimationsForTesting has been called, timeline currentTime is the pauseAt time.
