### PR TITLE
Support keyTimes in keyframe animations

### DIFF
--- a/test/testcases/keyTimes-check.js
+++ b/test/testcases/keyTimes-check.js
@@ -1,0 +1,17 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillRect = document.getElementById('polyfillRect');
+  var nativeRect = document.getElementById('nativeRect');
+
+  at(0 * 2000, 'width', 100, polyfillRect, nativeRect);
+  at(0.2 * 2000, 'width', 50, polyfillRect, nativeRect);
+  at(0.4 * 2000, 'width', 0, polyfillRect, nativeRect);
+  at(0.45 * 2000, 'width', 25, polyfillRect, nativeRect);
+  at(0.5 * 2000, 'width', 50, polyfillRect, nativeRect);
+  at(0.55 * 2000, 'width', 25, polyfillRect, nativeRect);
+  at(0.6 * 2000, 'width', 0, polyfillRect, nativeRect);
+  at(0.8 * 2000, 'width', 50, polyfillRect, nativeRect);
+  at(1 * 2000, 'width', 100, polyfillRect, nativeRect);
+
+}, 'keyTimes width');

--- a/test/testcases/keyTimes.html
+++ b/test/testcases/keyTimes.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="keyTimes-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="250">
+  <rect id="polyfillRect" x="0" y="0" width="100" height="100" fill="green">
+    <animate attributeName="width" values="100;0;50;0;100" keyTimes="0;0.4;0.5;0.6;1" dur="2s" repeatCount="2"/>
+  </rect>
+
+  <rect id="nativeRect" x="0" y="110" width="100" height="100" fill="green">
+    <nativeAnimate attributeName="width" values="100;0;50;0;100" keyTimes="0;0.4;0.5;0.6;1" dur="2s" repeatCount="2"/>
+  </rect>
+</svg>
+
+  </body>
+</html>


### PR DESCRIPTION
Add support for the keyTimes attribute, used to control the times in [0..1] at
which supplied values take effect.
