### PR TITLE
Avoid null transform error in polyfill

### DIFF
--- a/web-animations.js
+++ b/web-animations.js
@@ -5330,12 +5330,16 @@ var ensureTargetSVGInitialised = function(property, target) {
     Object.defineProperty(target.actuals, property, configureDescriptor({
       set: function(value) {
         if (value === null) {
-          target._actuals[property] = target._bases[property];
-          target._setAttribute(property, target._bases[property]);
-        } else {
-          target._actuals[property] = value;
-          target._setAttribute(property, value);
+          value = target._bases[property];
+          if (value === null && property === 'transform') {
+            // Avoid SVG error:
+            // Invalid value for <element> attribute transform="null"
+            value = '';
+          }
         }
+
+        target._actuals[property] = value;
+        target._setAttribute(property, value);
       },
       get: function() {
         return target._actuals[property];


### PR DESCRIPTION
The Web Animations Polyfill no longer reports an error when the SVG
transforms for the motion path complete, as we use '' instead of null as
the default transform value.

Similarly, we avoid reporting errors during motion path animations when additive="sum".
animateMotion-iterationComposite.html exercises this case.
