### PR TITLE
Strengthen test expectations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,5 @@ svg-animations.js: web-animations.js smil-in-javascript.js
 clean:
 	rm -f svg-animations.js smil-in-javascript-4lint.js
 
-lint: smil-in-javascript.js test/harness.js
+lint: smil-in-javascript.js test/harness.js test/testcases/*.js
 	./run-lint.sh

--- a/run-lint.sh
+++ b/run-lint.sh
@@ -15,5 +15,5 @@ fi
 # Comment out the (function() {} ) wrapper
 sed -e'17s-^-//-' -e'$s-^-//-' smil-in-javascript.js > smil-in-javascript-4lint.js
 
-gjslint --summary --nojsdoc smil-in-javascript-4lint.js test/harness.js && rm smil-in-javascript-4lint.js
+gjslint --summary --nojsdoc smil-in-javascript-4lint.js test/harness.js test/testcases/*.js && rm smil-in-javascript-4lint.js
 exit $?

--- a/test/harness.js
+++ b/test/harness.js
@@ -71,8 +71,8 @@ function timing_test_impl(callback, desc) {
 
     var matched = false;
     if (Array.isArray(expectedValue)) {
-      if (expectedValue.indexOf(polyfillAnimatedValue) > -1 &&
-          expectedValue.indexOf(nativeAnimatedValue) > -1) {
+      if (expectedValue.indexOf(polyfillAnimatedValue) === 0 &&
+          expectedValue.indexOf(nativeAnimatedValue) === 1) {
         matched = true;
       }
     } else {

--- a/test/testcases/animateTransform-check.js
+++ b/test/testcases/animateTransform-check.js
@@ -4,11 +4,14 @@ timing_test(function() {
   var polyfillRect = document.getElementById('polyfillRect');
   var nativeRect = document.getElementById('nativeRect');
 
-  at(0, 'transform', ['scale(1)', 'scale(1 1)'], polyfillRect, nativeRect);
-  at(500, 'transform', ['scale(1.5)', 'scale(1.5 1.5)'], polyfillRect, nativeRect);
-  at(1000, 'transform', ['scale(2)', 'scale(2 2)'], polyfillRect, nativeRect);
-  at(1500, 'transform', ['scale(2.5)', 'scale(2.5 2.5)'], polyfillRect, nativeRect);
-  // FIXME: final transform for polyfillRect should be '', not 'null'.
-  at(2500, 'transform', ['null', ''], polyfillRect, nativeRect);
+  at(0, 'transform',
+     ['scale(1)', 'scale(1 1)'], polyfillRect, nativeRect);
+  at(500, 'transform',
+     ['scale(1.5)', 'scale(1.5 1.5)'], polyfillRect, nativeRect);
+  at(1000, 'transform',
+     ['scale(2)', 'scale(2 2)'], polyfillRect, nativeRect);
+  at(1500, 'transform',
+     ['scale(2.5)', 'scale(2.5 2.5)'], polyfillRect, nativeRect);
+  at(2500, 'transform', '', polyfillRect, nativeRect);
 
 }, 'animateTransform scale');

--- a/test/testcases/freeze-check.js
+++ b/test/testcases/freeze-check.js
@@ -4,7 +4,7 @@ timing_test(function() {
   var polyfillRect = document.getElementById('polyfillRect');
   var nativeRect = document.getElementById('nativeRect');
 
-  // FIXME: enable width tests when Polyfill implements support for begin time(s).
+  // FIXME: enable width tests when Polyfill implements support for begin time
   // (width animation should begin after 2s, not immediately)
   at(0, 'x', 100, polyfillRect, nativeRect);
   at(500, 'height', 125, polyfillRect, nativeRect);

--- a/test/testcases/get-target-element-check.js
+++ b/test/testcases/get-target-element-check.js
@@ -6,11 +6,14 @@ timing_test(function() {
   var polyfillAnimation = document.getElementById('polyfillAnimation');
   var nativeAnimation = document.getElementById('nativeAnimation');
 
-  at(1200, 'targetElement', [polyfillRect, nativeRect], polyfillAnimation, nativeAnimation);
-  at(3200, 'targetElement', [polyfillRect, nativeRect], polyfillAnimation, nativeAnimation);
+  at(1200, 'targetElement',
+     [polyfillRect, nativeRect], polyfillAnimation, nativeAnimation);
+  at(3200, 'targetElement',
+     [polyfillRect, nativeRect], polyfillAnimation, nativeAnimation);
 }, 'targetElement');
 
-// FIXME: add test where the element with target id is deleted, and replaced by a new element.
+// FIXME: add test where the element with target id is deleted,
+// and replaced by a new element.
 
 // FIXME: add test where the xlink:href attribute is changed.
 


### PR DESCRIPTION
Where the polyfill and native implementation of SMIL are known to report
different attribute values, match the observed polyfill attribute value
against the expected polyfill attribute value, and the observed native
attribute value against the expected native attribute value.
