### PR TITLE
Only animate SVG elements

### DIFF
--- a/smil-in-javascript.js
+++ b/smil-in-javascript.js
@@ -355,10 +355,16 @@ function createAnimationRecord(element) {
   }
 
   var targetRef = animationRecord['xlink:href'];
-  if (targetRef && targetRef.indexOf('#') === 0) {
+  if (targetRef && targetRef[0] === '#') {
     targetRef = targetRef.substring(1);
     animationRecord.target =
         document.getElementById(targetRef);
+
+    if (!(animationRecord.target instanceof SVGElement)) {
+      // Only animate SVG elements
+      animationRecord.target = null;
+    }
+
     if (!animationRecord.target) {
       var waiting = waitingAnimationRecords[targetRef];
       if (!waiting) {
@@ -403,6 +409,10 @@ function walkSVG(node) {
     createMotionPathAnimation(animationRecords[node]);
   }
 
+  if (!(node instanceof SVGElement)) {
+    // Only animate SVG elements
+    return;
+  }
   var waitingList = waitingAnimationRecords[node.id];
   if (waitingList) {
     // FIXME: create animations in order by begin time

--- a/test/harness.js
+++ b/test/harness.js
@@ -54,6 +54,8 @@ function timing_test_impl(callback, desc) {
         return element.getStartTime();
       case 'currentTime':
         return element.getCurrentTime();
+      case 'css-transform':
+        return getComputedStyle(element).transform;
       default:
         // FIXME: getAttribute(expectation.propertyName) does not return
         // animated value for polyfillAnimatedElement but does for
@@ -89,8 +91,8 @@ function timing_test_impl(callback, desc) {
 
     var matched = false;
     if (Array.isArray(expectedValue)) {
-      if (expectedValue.indexOf(polyfillAnimatedValue) === 0 &&
-          expectedValue.indexOf(nativeAnimatedValue) === 1) {
+      if (expectedValue[0] === polyfillAnimatedValue &&
+          expectedValue[1] === nativeAnimatedValue) {
         matched = true;
       }
     } else {

--- a/test/testcases/skip-non-svg-targets-check.js
+++ b/test/testcases/skip-non-svg-targets-check.js
@@ -1,0 +1,38 @@
+'use strict';
+
+function createSet(id, href) {
+  var picture = document.getElementById('picture');
+
+  var set = document.createElementNS(
+      'http://www.w3.org/2000/svg', 'set');
+  set.id = id;
+
+  set.setAttributeNS(
+      'http://www.w3.org/1999/xlink', 'xlink:href', href);
+
+  var attributes = {
+    attributeName: 'transform',
+    to: 'scale(0.5)'
+  };
+
+  for (var name in attributes) {
+    set.setAttribute(name, attributes[name]);
+  }
+
+  picture.appendChild(set);
+}
+
+function createTargets() {
+  createSet('polyfillSet', '#polyfillDivBottom');
+  createSet('nativeSet', '#nativeDivBottom');
+}
+
+timing_test(function() {
+  executeAt(1000, createTargets);
+
+  at(2000, 'transform', undefined, 'polyfillDivTop', 'nativeDivTop');
+  at(2000, 'css-transform', 'none', 'polyfillDivTop', 'nativeDivTop');
+
+  at(3000, 'transform', undefined, 'polyfillDivBottom', 'nativeDivBottom');
+  at(3000, 'css-transform', 'none', 'polyfillDivBottom', 'nativeDivBottom');
+}, 'skip non-SVG target');

--- a/test/testcases/skip-non-svg-targets.html
+++ b/test/testcases/skip-non-svg-targets.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="skip-non-svg-targets-check.js"></script>
+
+    <style>
+      div {
+        width: 30px;
+        background-color: green;
+      }
+    </style>
+
+    <div id="polyfillDivTop" class="test">PT</div>
+    <div id="nativeDivTop" class="test">NT</div>
+    <div id="polyfillDivBottom" class="test">PB</div>
+    <div id="nativeDivBottom" class="test">NB</div>
+
+<svg id="picture" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="250">
+  <set xlink:href="#polyfillDivTop" attributeName="transform" to="scale(0.5)"/>
+  <nativeSet xlink:href="#nativeDivTop" attributeName="transform" to="scale(0.5)"/>
+
+  <!-- We create the following dynamically:
+  <set id="polyfillSet" xlink:href="#polyfillDivBottom" attributeName="transform" to="scale(0.5)"/>
+  <nativeSet id="nativeSet" xlink:href="#nativeDivBottom" attributeName="transform" to="scale(0.5)"/>
+  -->
+</svg>
+
+  </body>
+</html>


### PR DESCRIPTION
If the target (specified by id) is not an SVG element, we do not
animate it.

This applies both when the target element exists from the beginning and
when the target element is later appended to the document.
