### PR TITLE
Automated test for lists of begin, end times

### DIFF
--- a/smil-in-javascript.js
+++ b/smil-in-javascript.js
@@ -644,8 +644,13 @@ AnimationRecord.prototype = {
 
       var scheduleTime = this.endInstanceTimes.extractFirst().scheduleTime;
       if (this.startTime !== Infinity && this.player) {
-        this.player.pause();
-        this.player.currentTime = scheduleTime - this.player.startTime;
+        if (this.fill === 'freeze') {
+          this.player.pause();
+          this.player.currentTime = scheduleTime - this.player.startTime;
+        } else {
+          this.player.cancel();
+          this.player = null;
+        }
       }
       this.startTime = Infinity; // not playing
 
@@ -654,7 +659,7 @@ AnimationRecord.prototype = {
 
     this.updateMainSchedule();
   },
-  dispatchEvent : function(eventType, detailArg) {
+  dispatchEvent: function(eventType, detailArg) {
     // detailArg is the repeat count for repeat events
 
     var timeEvent = new Event(eventType);

--- a/test/harness.js
+++ b/test/harness.js
@@ -35,7 +35,7 @@ function timing_test_impl(callback, desc) {
       svgFragmentList[fragmentIndex].pauseAnimations();
       svgFragmentList[fragmentIndex].setCurrentTime(millis / 1000);
     }
-    document.timeline._pauseAnimationsForTesting(millis);
+    document.timeline._freezeClockForTesting(millis);
   }
 
   function readAttribute(element, propertyName) {
@@ -74,6 +74,13 @@ function timing_test_impl(callback, desc) {
     return Math.abs(first - second) < 1E-6;
   }
 
+  function match(observedValue, expectedValue) {
+    if (typeof expectedValue === 'number') {
+      return roughlyEqual(observedValue, expectedValue);
+    }
+    return observedValue === expectedValue;
+  }
+
   function verifyExpectation() {
     var expectation = expectationList[expectationIndex];
     if (expectation.command) {
@@ -89,22 +96,13 @@ function timing_test_impl(callback, desc) {
     var nativeAnimatedValue = readAttribute(
         expectation.nativeAnimatedElement, expectation.propertyName);
 
-    var matched = false;
+    var matched;
     if (Array.isArray(expectedValue)) {
-      if (expectedValue[0] === polyfillAnimatedValue &&
-          expectedValue[1] === nativeAnimatedValue) {
-        matched = true;
-      }
+      matched = match(polyfillAnimatedValue, expectedValue[0]) &&
+                match(nativeAnimatedValue, expectedValue[1]);
     } else {
-      if (typeof expectedValue == 'number') {
-        if (roughlyEqual(parseFloat(polyfillAnimatedValue), expectedValue) &&
-            roughlyEqual(parseFloat(nativeAnimatedValue), expectedValue)) {
-          matched = true;
-        }
-      } else if (polyfillAnimatedValue === expectedValue &&
-                 nativeAnimatedValue === expectedValue) {
-        matched = true;
-      }
+      matched = match(polyfillAnimatedValue, expectedValue) &&
+                match(nativeAnimatedValue, expectedValue);
     }
 
     if (verbose || !matched) {

--- a/test/testcases/simple-list-begin-end-check.js
+++ b/test/testcases/simple-list-begin-end-check.js
@@ -1,0 +1,32 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillCircle = document.getElementById('polyfillCircle');
+  var nativeCircle = document.getElementById('nativeCircle');
+
+  at(0, 'cx', 200, polyfillCircle, nativeCircle);
+  at(500, 'cy', 220, polyfillCircle, nativeCircle);
+  at(1000, 'r', 10, polyfillCircle, nativeCircle);
+  at(2000, 'cx', 220, polyfillCircle, nativeCircle);
+  at(2500, 'cy', 260, polyfillCircle, nativeCircle);
+  at(3000, 'r', 110, polyfillCircle, nativeCircle);
+  at(4000, 'cx', 240, polyfillCircle, nativeCircle);
+  at(4500, 'cy', 300, polyfillCircle, nativeCircle);
+  // nativeCircle's r 10 is incorrect - should freeze at 120
+  at(5000, 'r', [120, 10], polyfillCircle, nativeCircle);
+  at(6000, 'cx', 260, polyfillCircle, nativeCircle);
+  at(6500, 'cy', 340, polyfillCircle, nativeCircle);
+  at(7000, 'r', 110, polyfillCircle, nativeCircle);
+  at(8000, 'cx', 280, polyfillCircle, nativeCircle);
+  at(8500, 'cy', 220, polyfillCircle, nativeCircle);
+  at(9000, 'r', 110, polyfillCircle, nativeCircle);
+  at(10000, 'cx', 300, polyfillCircle, nativeCircle);
+  at(10500, 'cy', 260, polyfillCircle, nativeCircle);
+  at(11000, 'r', 120, polyfillCircle, nativeCircle);
+  at(12000, 'cx', 300, polyfillCircle, nativeCircle);
+  at(12500, 'cy', 300, polyfillCircle, nativeCircle);
+  at(13000, 'r', 120, polyfillCircle, nativeCircle);
+  at(14000, 'cx', 300, polyfillCircle, nativeCircle);
+  at(14500, 'cy', 310, polyfillCircle, nativeCircle);
+  at(15000, 'r', 120, polyfillCircle, nativeCircle);
+}, 'begin/end list');

--- a/test/testcases/simple-list-begin-end.html
+++ b/test/testcases/simple-list-begin-end.html
@@ -3,17 +3,20 @@
   <body>
     <script src="../../web-animations.js"></script>
     <script src="../../smil-in-javascript.js"></script>
-    <!-- FIXME: use the test harness
     <script src="../harness.js"></script>
-    <script src="simple-list-begin-end-check.js"></script> -->
+    <script src="simple-list-begin-end-check.js"></script>
 
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="600" height="600">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="600" height="800">
   <circle id="polyfillCircle" cx="300" cy="300" r="10" fill="green" opacity="0.5">
-    <animate attributeName="r" from="200" to="100" dur="4s" begin="1s;3s;4s" end="0s;2s;5s;6s" fill="freeze"/>
+    <animate id="polyfillAnimR" attributeName="r" from="100" to="180" dur="8s" begin="2s;6s;8s" end="0s;4s;10s;12s" fill="freeze"/>
+    <animate id="polyfillAnimCX" attributeName="cx" from="200" to="400" dur="20s" begin="0s;indefinite" end="11s;indefinite"/>
+    <animate id="polyfillAnimCY" attributeName="cy" from="200" to="600" dur="20s" begin="-500ms;7500ms;indefinite" end="13s;indefinite" fill="freeze"/>
   </circle>
 
   <circle id="nativeCircle" cx="300" cy="300" r="10" fill="red" opacity="0.5">
-    <nativeAnimate attributeName="r" from="200" to="100" dur="4s" begin="1s;3s;4s" end="0s;2s;5s;6s" fill="freeze"/>
+    <nativeAnimate id="polyfillAnimR" attributeName="r" from="100" to="180" dur="8s" begin="2s;6s;8s" end="0s;4s;10s;12s" fill="freeze"/>
+    <nativeAnimate id="polyfillAnimCX" attributeName="cx" from="200" to="400" dur="20s" begin="0s;indefinite" end="11s;indefinite"/>
+    <nativeAnimate id="polyfillAnimCY" attributeName="cy" from="200" to="600" dur="20s" begin="-500ms;7500ms;indefinite" end="13s;indefinite" fill="freeze"/>
   </circle>
 </svg>
 

--- a/web-animations.js
+++ b/web-animations.js
@@ -289,6 +289,9 @@ AnimationTimeline.prototype = {
       player.currentTime = pauseAt;
     });
 
+    this._freezeClockForTesting(pauseAt);
+  },
+  _freezeClockForTesting: function(pauseAt) {
     delete this.currentTime;
     Object.defineProperty(this, 'currentTime', {
       configurable: true,


### PR DESCRIPTION
We were calling _pauseAnimationsForTesting but that changes the players - in particular, it changes their start time. We now fix the animation clock at a particular time, without modifying the players.

When an animations ends, we were not handling the 'freeze' attribute correctly - we were letting every animation freeze at the values from the time the animation ended.
