### PR TITLE
Update orphan-mpath to use test harness

### DIFF
--- a/test/testcases/orphan-mpath-check.js
+++ b/test/testcases/orphan-mpath-check.js
@@ -1,0 +1,12 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillRect = document.getElementById('polyfillRect');
+  var nativeRect = document.getElementById('nativeRect');
+
+  at(1000, 'transform', ['translate(120, 80) rotate(0)', undefined], polyfillRect, nativeRect);
+  at(2000, 'transform', ['translate(210, 70) rotate(0)', undefined], polyfillRect, nativeRect);
+  at(3000, 'transform', ['translate(30, 90) rotate(0)', undefined], polyfillRect, nativeRect);
+  at(4000, 'transform', ['translate(120, 80) rotate(0)', undefined], polyfillRect, nativeRect);
+
+}, 'orphan mpath does not prevent unrelated animation');

--- a/test/testcases/orphan-mpath.html
+++ b/test/testcases/orphan-mpath.html
@@ -3,15 +3,17 @@
   <body>
     <script src="../../web-animations.js"></script>
     <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="orphan-mpath-check.js"></script>
 
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="500">
-  <rect width="40" height="40" fill="green" opacity="0.5">
-    <animateMotion calcMode="linear" dur="2s" repeatCount="indefinite"
-      path="M 100 100 L 300 50"/>
+  <rect id="polyfillRect" width="40" height="40" fill="green" opacity="0.5">
+    <animateMotion calcMode="linear" dur="3s" repeatCount="indefinite"
+      path="M 30 90 L 300 60"/>
   </rect>
-  <rect width="40" height="40" fill="red" opacity="0.5">
-    <nativeAnimateMotion calcMode="linear" dur="2s" repeatCount="indefinite"
-      path="M 100 100 L 300 50"/>
+  <rect id="nativeRect" width="40" height="40" fill="red" opacity="0.5">
+    <nativeAnimateMotion calcMode="linear" dur="3s" repeatCount="indefinite"
+      path="M 30 90 L 300 60"/>
   </rect>
 
   <!-- This mpath element has no animateMotion parent. -->


### PR DESCRIPTION
orphan-mpath simply has an mpath element without an animateMotion parent, and verifies that unrelated animations still run correctly.
