### PR TITLE
Support paced calcMode

### DIFF
--- a/smil-in-javascript.js
+++ b/smil-in-javascript.js
@@ -304,6 +304,10 @@ function createTimingInput(animationRecord) {
     // where we must inspect the inherited fillDefault attribute.
   }
 
+  if (animationRecord.calcMode === 'paced') {
+    timingInput.easing = 'paced';
+  }
+
   return timingInput;
 }
 

--- a/test/testcases/animateMotion-autoReverse-check.js
+++ b/test/testcases/animateMotion-autoReverse-check.js
@@ -1,0 +1,69 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillForwards = document.getElementById('polyfillForwards');
+  var polyfillBackwards = document.getElementById('polyfillBackwards');
+  var nativeForwards = document.getElementById('nativeForwards');
+  var nativeBackwards = document.getElementById('nativeBackwards');
+
+  at(0, 'transform',
+      ['translate(100, 700) ' +
+       'rotate(81.87608710023423)', undefined],
+      polyfillForwards, nativeForwards);
+  at(1000, 'transform',
+      ['translate(325.6376953125, 602.1029052734375) ' +
+       'rotate(127.35662192852043)', undefined],
+      polyfillBackwards, nativeBackwards);
+  at(2000, 'transform',
+      ['translate(342.12249755859375, 497.4693298339844) ' +
+       'rotate(-58.10590660892704)', undefined],
+      polyfillForwards, nativeForwards);
+  at(3000, 'transform',
+      ['translate(509.8045349121094, 330.6245422363281) ' +
+       'rotate(125.15013659963918)', undefined],
+      polyfillBackwards, nativeBackwards);
+  at(4000, 'transform',
+      ['translate(515.7870483398438, 217.8354949951172) ' +
+       'rotate(-52.378094708887936)', undefined],
+      polyfillForwards, nativeForwards);
+  at(5000, 'transform',
+      ['translate(745.2967529296875, 109.2613525390625) ' +
+       'rotate(161.37120442680765)', undefined],
+      polyfillBackwards, nativeBackwards);
+  at(6000, 'transform',
+      ['translate(627.4202880859375, 172.5797119140625) ' +
+       'rotate(135)', undefined], polyfillForwards,
+      nativeForwards);
+  at(7000, 'transform',
+      ['translate(607.3983154296875, 292.6017150878906) ' +
+       'rotate(315)', undefined], polyfillBackwards,
+      nativeBackwards);
+  at(8000, 'transform',
+      ['translate(394.5208435058594, 405.4791564941406) ' +
+       'rotate(135)', undefined], polyfillForwards,
+      nativeForwards);
+  at(9000, 'transform',
+      ['translate(375.39190673828125, 524.6080932617188) ' +
+       'rotate(315)', undefined], polyfillBackwards,
+      nativeBackwards);
+  at(10000, 'transform',
+      ['translate(161.62142944335938, 638.3785400390625) ' +
+       'rotate(135)', undefined], polyfillForwards,
+      nativeForwards);
+  at(11000, 'transform',
+      ['translate(241.10150146484375, 631.2932739257812) ' +
+       'rotate(121.63603599862758)', undefined],
+      polyfillBackwards, nativeBackwards);
+  at(12000, 'transform',
+      ['translate(233.18544006347656, 497.939453125) ' +
+       'rotate(-50.99931178700786)', undefined],
+      polyfillForwards, nativeForwards);
+  at(13000, 'transform',
+      ['translate(422.3974914550781, 487.8026428222656) ' +
+       'rotate(283.55842772575784)', undefined],
+      polyfillBackwards, nativeBackwards);
+  at(14000, 'transform',
+      ['translate(243.4203643798828, 629.0626220703125) ' +
+       'rotate(133.02506598911802)', undefined],
+      polyfillForwards, nativeForwards);
+}, 'auto reverse');

--- a/test/testcases/animateMotion-autoReverse.html
+++ b/test/testcases/animateMotion-autoReverse.html
@@ -3,17 +3,29 @@
   <body>
     <script src="../../web-animations.js"></script>
     <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="animateMotion-autoReverse-check.js"></script>
 
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="800" height="800">
-  <rect width="40" height="20" fill="green" opacity="0.5">
-    <animateMotion calcMode="linear" path="M 100 700 C 352 700 448 100 700 100 Z C 448 100 352 700 100 700"
-      dur="15s" repeatCount="indefinite" rotate="auto-reverse"/>
-  </rect>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="900" height="900">
+  <polyline id="polyfillForwards" points="0,0 40,10 0,20 10,10" fill="green" opacity="0.5">
+    <animateMotion path="M 100 700 C 352 700 448 100 700 100 Z C 448 100 352 700 100 700"
+      calcMode="paced" dur="15s" repeatCount="indefinite" rotate="auto"/>
+  </polyline>
 
-  <rect width="40" height="20" fill="red" opacity="0.5">
-    <nativeAnimateMotion calcMode="linear" path="M 100 700 C 352 700 448 100 700 100 Z C 448 100 352 700 100 700"
-      dur="15s" repeatCount="indefinite" rotate="auto-reverse"/>
-  </rect>
+  <polyline id="nativeForwards" points="0,0 40,10 0,20 10,10" fill="red" opacity="0.5">
+    <nativeAnimateMotion path="M 100 700 C 352 700 448 100 700 100 Z C 448 100 352 700 100 700"
+      calcMode="paced" dur="15s" repeatCount="indefinite" rotate="auto"/>
+  </polyline>
+
+  <polyline id="polyfillBackwards" points="0,0 40,10 0,20 10,10" fill="green" opacity="0.5">
+    <animateMotion path="M 200 700 C 352 700 548 100 800 100 Z C 548 100 452 700 200 700"
+      calcMode="paced" dur="15s" repeatCount="indefinite" rotate="auto-reverse"/>
+  </polyline>
+
+  <polyline id="nativeBackwards" points="0,0 40,10 0,20 10,10" fill="red" opacity="0.5">
+    <nativeAnimateMotion path="M 200 700 C 352 700 548 100 800 100 Z C 548 100 452 700 200 700"
+      calcMode="paced" dur="15s" repeatCount="indefinite" rotate="auto-reverse"/>
+  </polyline>
 </svg>
 
   </body>


### PR DESCRIPTION
Support the calcMode="paced" timing option. When this option is used, the timing for our polyfill animation matches that of the native animation, for motion path animation over a Bezier path. (With calcMode="linear", this does not occur as Chrome's native animation does not correctly support calcMode="linear".)

Automate test/testcases/animateMotion-autoReverse. This test wasn't previously automated as the polyfill and native implementation did not match in observed behavior.
