### PR TITLE
Avoid long lines in tests (lint fix)

### DIFF
--- a/test/testcases/animateMotion-iterationComposite-check.js
+++ b/test/testcases/animateMotion-iterationComposite-check.js
@@ -4,11 +4,26 @@ timing_test(function() {
   var polyfillRect = document.getElementById('polyfillRect');
   var nativeRect = document.getElementById('nativeRect');
 
-  at(1000, 'transform', ['translate(45, -60) rotate(0) translate(-75, 180) rotate(0)', undefined], polyfillRect, nativeRect);
-  at(2000, 'transform', ['translate(90, -120) rotate(0) translate(-50, 120) rotate(0)', undefined], polyfillRect, nativeRect);
-  at(3000, 'transform', ['translate(105, -140) rotate(0) translate(-75, 180) rotate(0)', undefined], polyfillRect, nativeRect);
-  at(4000, 'transform', ['translate(150, -200) rotate(0) translate(-50, 120) rotate(0)', undefined], polyfillRect, nativeRect);
-  at(5000, 'transform', ['translate(165, -220) rotate(0) translate(-75, 180) rotate(0)', undefined], polyfillRect, nativeRect);
+  at(1000, 'transform',
+      ['translate(45, -60) rotate(0) translate(-75, 180) rotate(0)',
+       undefined],
+      polyfillRect, nativeRect);
+  at(2000, 'transform',
+      ['translate(90, -120) rotate(0) translate(-50, 120) rotate(0)',
+       undefined],
+      polyfillRect, nativeRect);
+  at(3000, 'transform',
+      ['translate(105, -140) rotate(0) translate(-75, 180) rotate(0)',
+       undefined],
+      polyfillRect, nativeRect);
+  at(4000, 'transform',
+      ['translate(150, -200) rotate(0) translate(-50, 120) rotate(0)',
+       undefined],
+      polyfillRect, nativeRect);
+  at(5000, 'transform',
+      ['translate(165, -220) rotate(0) translate(-75, 180) rotate(0)',
+       undefined],
+      polyfillRect, nativeRect);
 
   // Without this extra expectation (and RAF), the final
   // transform is mis-reported. We need the animation

--- a/test/testcases/begin-end-element-check.js
+++ b/test/testcases/begin-end-element-check.js
@@ -24,12 +24,17 @@ timing_test(function() {
 
   executeAt(1000, beginElements);
   at(2000, 'transform', undefined, polyfillSecondRect, nativeSecondRect);
-  at(3000, 'transform', 'translate(-20, 120)', polyfillFirstRect, nativeFirstRect);
-  at(5000, 'transform', 'translate(-40, 90)', polyfillFirstRect, nativeFirstRect);
-  at(6000, 'transform', 'translate(10, -160)', polyfillSecondRect, nativeSecondRect);
+  at(3000, 'transform', 'translate(-20, 120)',
+      polyfillFirstRect, nativeFirstRect);
+  at(5000, 'transform', 'translate(-40, 90)',
+      polyfillFirstRect, nativeFirstRect);
+  at(6000, 'transform', 'translate(10, -160)',
+      polyfillSecondRect, nativeSecondRect);
   executeAt(8000, endElements);
-  at(9000, 'transform', 'translate(-20, 120)', polyfillFirstRect, nativeFirstRect);
+  at(9000, 'transform', 'translate(-20, 120)',
+      polyfillFirstRect, nativeFirstRect);
   at(10000, 'transform', '', polyfillSecondRect, nativeSecondRect);
   at(12000, 'transform', '', polyfillSecondRect, nativeSecondRect);
-  at(13000, 'transform', 'translate(-40, 90)', polyfillFirstRect, nativeFirstRect);
+  at(13000, 'transform', 'translate(-40, 90)',
+      polyfillFirstRect, nativeFirstRect);
 }, 'beginElement');

--- a/test/testcases/orphan-mpath-check.js
+++ b/test/testcases/orphan-mpath-check.js
@@ -4,9 +4,13 @@ timing_test(function() {
   var polyfillRect = document.getElementById('polyfillRect');
   var nativeRect = document.getElementById('nativeRect');
 
-  at(1000, 'transform', ['translate(120, 80) rotate(0)', undefined], polyfillRect, nativeRect);
-  at(2000, 'transform', ['translate(210, 70) rotate(0)', undefined], polyfillRect, nativeRect);
-  at(3000, 'transform', ['translate(30, 90) rotate(0)', undefined], polyfillRect, nativeRect);
-  at(4000, 'transform', ['translate(120, 80) rotate(0)', undefined], polyfillRect, nativeRect);
+  at(1000, 'transform', ['translate(120, 80) rotate(0)', undefined],
+      polyfillRect, nativeRect);
+  at(2000, 'transform', ['translate(210, 70) rotate(0)', undefined],
+      polyfillRect, nativeRect);
+  at(3000, 'transform', ['translate(30, 90) rotate(0)', undefined],
+      polyfillRect, nativeRect);
+  at(4000, 'transform', ['translate(120, 80) rotate(0)', undefined],
+      polyfillRect, nativeRect);
 
 }, 'orphan mpath does not prevent unrelated animation');


### PR DESCRIPTION
Avoid long lines in the following tests:
- animateMotion-iterationComposite
- begin-end-element
- orphan-mpath
