### PR TITLE
Automated test for begin and event events

### DIFF
--- a/smil-in-javascript.js
+++ b/smil-in-javascript.js
@@ -651,10 +651,10 @@ AnimationRecord.prototype = {
           this.player.cancel();
           this.player = null;
         }
+
+        this.dispatchEvent('end', 0);
       }
       this.startTime = Infinity; // not playing
-
-      this.dispatchEvent('end', 0);
     }
 
     this.updateMainSchedule();

--- a/test/testcases/begin-end-events-check.js
+++ b/test/testcases/begin-end-events-check.js
@@ -1,0 +1,20 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillAnim = document.getElementById('polyfillAnim');
+  var nativeAnim = document.getElementById('nativeAnim');
+
+  function requentEnd() {
+    polyfillAnim.endElement();
+  }
+
+  executeAt(500, requentEnd); // NOOP
+  eventAt(1000, polyfillAnim, 'begin');
+  eventAt(2000, polyfillAnim, 'end');
+  eventAt(3000, polyfillAnim, 'begin');
+  eventAt(4000, polyfillAnim, 'end');
+  eventAt(4000, polyfillAnim, 'begin');
+  eventAt(5000, polyfillAnim, 'end');
+  executeAt(5500, requentEnd); // NOOP
+
+}, 'begin and end events');

--- a/test/testcases/begin-end-events.html
+++ b/test/testcases/begin-end-events.html
@@ -3,9 +3,8 @@
   <body>
     <script src="../../web-animations.js"></script>
     <script src="../../smil-in-javascript.js"></script>
-    <!-- FIXME: use the test harness
     <script src="../harness.js"></script>
-    <script src="begin-events.js"></script> -->
+    <script src="begin-end-events-check.js"></script>
 
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="600" height="600">
   <circle id="polyfillCircle" cx="300" cy="300" r="10" fill="green" opacity="0.5">
@@ -16,68 +15,6 @@
     <nativeAnimate id="nativeAnim" attributeName="r" from="200" to="100" dur="4s" begin="1s;3s;4s" end="0s;2s;5s;6s" fill="freeze"/>
   </circle>
 </svg>
-
-<script>
-
-// FIXME: move this test to the test harness
-
-var expectedCalls = [
-  'polyfillBegin',
-  'polyfillEnd',
-  'polyfillBegin',
-  'polyfillEnd',
-  'polyfillBegin',
-  'polyfillEnd',
-  'polyfillEnd'
-];
-
-function assert(condition, message) {
-  console.log((condition ? 'PASSED: ' : 'FAILED: ') + message);
-}
-
-function processEvent(name, e) {
-  var polyfillAnim = document.getElementById('polyfillAnim');
-
-  assert(expectedCalls.length && name === expectedCalls[0], 'event name');
-  expectedCalls.shift();
-
-  assert(e.target == polyfillAnim, 'event target');
-  assert(e.view == document.defaultView, 'event view');
-  assert(e.detail.toString() === '0', 'event detail');
-
-  if (!expectedCalls.length) {
-    console.log('PASSED events test');
-  }
-}
-
-function polyfillBegin(e) {
-  processEvent('polyfillBegin', e);
-}
-
-function polyfillEnd(e) {
-  processEvent('polyfillEnd', e);
-}
-
-function nativeBegin(e) {
-  processEvent('nativeBegin', e);
-}
-
-function nativeEnd(e) {
-  processEvent('nativeEnd', e);
-}
-
-function registerListeners() {
-  var polyfillAnim = document.getElementById('polyfillAnim');
-  var nativeAnim = document.getElementById('nativeAnim');
-  polyfillAnim.addEventListener('begin', polyfillBegin);
-  polyfillAnim.addEventListener('end', polyfillEnd);
-  nativeAnim.addEventListener('begin', nativeBegin);
-  nativeAnim.addEventListener('end', nativeEnd);
-}
-
-window.addEventListener('load', registerListeners);
-
-</script>
 
   </body>
 </html>


### PR DESCRIPTION
The test harness now supports begin and end event expectations.

The test begin-end-events.html now uses the test harness.

Bug fix: We no longer issue an end event if the animation never
started, or has already ended.
