### PR TITLE
Clarify simple-list-begin-end test

### DIFF
--- a/test/testcases/simple-list-begin-end-check.js
+++ b/test/testcases/simple-list-begin-end-check.js
@@ -23,10 +23,10 @@ timing_test(function() {
   at(10000, 'cx', 300, polyfillCircle, nativeCircle);
   at(10500, 'cy', 260, polyfillCircle, nativeCircle);
   at(11000, 'r', 120, polyfillCircle, nativeCircle);
-  at(12000, 'cx', 300, polyfillCircle, nativeCircle);
+  at(12000, 'cx', 100, polyfillCircle, nativeCircle); // initial value
   at(12500, 'cy', 300, polyfillCircle, nativeCircle);
-  at(13000, 'r', 120, polyfillCircle, nativeCircle);
-  at(14000, 'cx', 300, polyfillCircle, nativeCircle);
-  at(14500, 'cy', 310, polyfillCircle, nativeCircle);
-  at(15000, 'r', 120, polyfillCircle, nativeCircle);
+  at(13000, 'r', 120, polyfillCircle, nativeCircle); // frozen value
+  at(14000, 'cx', 100, polyfillCircle, nativeCircle); // initial value
+  at(14500, 'cy', 310, polyfillCircle, nativeCircle); // frozen value
+  at(15000, 'r', 120, polyfillCircle, nativeCircle); // frozen value
 }, 'begin/end list');

--- a/test/testcases/simple-list-begin-end.html
+++ b/test/testcases/simple-list-begin-end.html
@@ -7,13 +7,14 @@
     <script src="simple-list-begin-end-check.js"></script>
 
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="600" height="800">
-  <circle id="polyfillCircle" cx="300" cy="300" r="10" fill="green" opacity="0.5">
+  <circle id="polyfillCircle" cx="100" cy="100" r="10" fill="green" opacity="0.5">
     <animate id="polyfillAnimR" attributeName="r" from="100" to="180" dur="8s" begin="2s;6s;8s" end="0s;4s;10s;12s" fill="freeze"/>
+    <!-- We omit fill freeze in our animation of cx -->
     <animate id="polyfillAnimCX" attributeName="cx" from="200" to="400" dur="20s" begin="0s;indefinite" end="11s;indefinite"/>
     <animate id="polyfillAnimCY" attributeName="cy" from="200" to="600" dur="20s" begin="-500ms;7500ms;indefinite" end="13s;indefinite" fill="freeze"/>
   </circle>
 
-  <circle id="nativeCircle" cx="300" cy="300" r="10" fill="red" opacity="0.5">
+  <circle id="nativeCircle" cx="100" cy="100" r="10" fill="red" opacity="0.5">
     <nativeAnimate id="polyfillAnimR" attributeName="r" from="100" to="180" dur="8s" begin="2s;6s;8s" end="0s;4s;10s;12s" fill="freeze"/>
     <nativeAnimate id="polyfillAnimCX" attributeName="cx" from="200" to="400" dur="20s" begin="0s;indefinite" end="11s;indefinite"/>
     <nativeAnimate id="polyfillAnimCY" attributeName="cy" from="200" to="600" dur="20s" begin="-500ms;7500ms;indefinite" end="13s;indefinite" fill="freeze"/>


### PR DESCRIPTION
Add comments to simple-list-begin-end indicating that the cx property reverts to its initial value as the animation is not fill=freeze, unlike for the other properties animated in the test.
