### PR TITLE
Explicitly wait for DOM mutation observer in test

### DIFF
--- a/test/testcases/animateMotion-iterationComposite-check.js
+++ b/test/testcases/animateMotion-iterationComposite-check.js
@@ -24,13 +24,6 @@ timing_test(function() {
       ['translate(165, -220) rotate(0) translate(-75, 180) rotate(0)',
        undefined],
       polyfillRect, nativeRect);
-
-  // Without this extra expectation (and RAF), the final
-  // transform is mis-reported. We need the animation
-  // completion to be observed before the RAF where we
-  // inspect transform.
-  at(7000, 'width', 200, polyfillRect, nativeRect);
-
   at(8000, 'transform', ['', undefined], polyfillRect, nativeRect);
 
 }, 'animateTransform scale');

--- a/test/testcases/append-target-check.js
+++ b/test/testcases/append-target-check.js
@@ -30,10 +30,7 @@ function createTargets() {
 timing_test(function() {
   executeAt(1000, createTargets);
 
-  // Without this extra expectation (and RAF), the width
-  // is reported as 100. We need the DOM mutations to be
-  // observed before the RAF where we inspect width.
-  at(2000, 'height', '100', 'polyfillRect', 'nativeRect');
+  observeMutationsAt(2000);
 
   at(3000, 'width', '200', 'polyfillRect', 'nativeRect');
 }, 'append animation target');


### PR DESCRIPTION
Our test harness now allows us to wait for DOM mutations to be reported.

Previously, the append-target test was waiting for an extra RAF as a way
of providing time for mutations to be observed. Now we are explicit, and
more robust in the event that the machine is heavily loaded.

The test harness scheduler event handling code has been refactored to
improve consistency and reduce code duplication.
