### PR TITLE
Improve robustness of begin/end events test

### DIFF
--- a/test/testcases/begin-end-events-check.js
+++ b/test/testcases/begin-end-events-check.js
@@ -8,13 +8,13 @@ timing_test(function() {
     polyfillAnim.endElement();
   }
 
-  executeAt(500, requentEnd); // NOOP
-  eventAt(1000, polyfillAnim, 'begin');
-  eventAt(2000, polyfillAnim, 'end');
-  eventAt(3000, polyfillAnim, 'begin');
-  eventAt(4000, polyfillAnim, 'end');
-  eventAt(4000, polyfillAnim, 'begin');
-  eventAt(5000, polyfillAnim, 'end');
-  executeAt(5500, requentEnd); // NOOP
+  executeAt(32000, requentEnd); // NOOP
+  eventAt(36000, polyfillAnim, 'begin');
+  eventAt(40000, polyfillAnim, 'end');
+  eventAt(44000, polyfillAnim, 'begin');
+  eventAt(48000, polyfillAnim, 'end');
+  eventAt(48000, polyfillAnim, 'begin');
+  eventAt(52000, polyfillAnim, 'end');
+  executeAt(60000, requentEnd); // NOOP
 
 }, 'begin and end events');

--- a/test/testcases/begin-end-events.html
+++ b/test/testcases/begin-end-events.html
@@ -8,11 +8,11 @@
 
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="600" height="600">
   <circle id="polyfillCircle" cx="300" cy="300" r="10" fill="green" opacity="0.5">
-    <animate id="polyfillAnim" attributeName="r" from="200" to="100" dur="4s" begin="1s;3s;4s" end="0s;2s;5s;6s" fill="freeze"/>
+    <animate id="polyfillAnim" attributeName="r" from="200" to="100" dur="4s" begin="36s;44s;48s" end="32s;40s;52s;56s" fill="freeze"/>
   </circle>
 
   <circle id="nativeCircle" cx="300" cy="300" r="10" fill="red" opacity="0.5">
-    <nativeAnimate id="nativeAnim" attributeName="r" from="200" to="100" dur="4s" begin="1s;3s;4s" end="0s;2s;5s;6s" fill="freeze"/>
+    <nativeAnimate id="polyfillAnim" attributeName="r" from="200" to="100" dur="4s" begin="36s;44s;48s" end="32s;40s;52s;56s" fill="freeze"/>
   </circle>
 </svg>
 


### PR DESCRIPTION
If the machine is busy while running the begin-end-events test, the events may be issued before the test is ready for them. We move the begin and end times back tens of seconds to avoid such issues.

(This does not cause the test to run any more slowly, as we advance the clock once the test has started.)

This robustness change is important when we run many tests concurrently.
