### PR TITLE
Test animateTransform transforms

### DIFF
--- a/test/testcases/animateTransform-check.js
+++ b/test/testcases/animateTransform-check.js
@@ -12,6 +12,63 @@ timing_test(function() {
      ['scale(2)', 'scale(2 2)'], polyfillRect, nativeRect);
   at(1500, 'transform',
      ['scale(2.5)', 'scale(2.5 2.5)'], polyfillRect, nativeRect);
-  at(2500, 'transform', '', polyfillRect, nativeRect);
 
-}, 'animateTransform scale');
+  at(2500, 'transform',
+     ['scale(2.75, 3.25)', 'scale(2.75 3.25)'], polyfillRect, nativeRect);
+  at(3000, 'transform',
+     ['scale(2.5, 3.5)', 'scale(2.5 3.5)'], polyfillRect, nativeRect);
+  at(3500, 'transform',
+     ['scale(2.25, 3.75)', 'scale(2.25 3.75)'], polyfillRect, nativeRect);
+
+  at(4000, 'transform',
+    ['translate(100, 0)', 'translate(100 0)'], polyfillRect, nativeRect);
+  at(4500, 'transform',
+     ['translate(150, 0)', 'translate(150 0)'], polyfillRect, nativeRect);
+  at(5000, 'transform',
+     ['translate(200, 0)', 'translate(200 0)'], polyfillRect, nativeRect);
+  at(5500, 'transform',
+     ['translate(250, 0)', 'translate(250 0)'], polyfillRect, nativeRect);
+
+  at(6500, 'transform',
+     ['translate(275, 325)', 'translate(275 325)'], polyfillRect, nativeRect);
+  at(7000, 'transform',
+     ['translate(250, 350)', 'translate(250 350)'], polyfillRect, nativeRect);
+  at(7500, 'transform',
+     ['translate(225, 375)', 'translate(225 375)'], polyfillRect, nativeRect);
+
+  at(8000, 'transform',
+     'rotate(0)', polyfillRect, nativeRect);
+  at(8500, 'transform',
+     'rotate(10)', polyfillRect, nativeRect);
+  at(9000, 'transform',
+     'rotate(20)', polyfillRect, nativeRect);
+  at(9500, 'transform',
+     'rotate(30)', polyfillRect, nativeRect);
+
+  // FIXME: polyfill should support rotate with <rotate-angle> <cx> <cy>
+  at(10500, 'transform',
+     ['', 'rotate(30 100 50)'], polyfillRect, nativeRect);
+  at(11000, 'transform',
+     ['', 'rotate(20 200 100)'], polyfillRect, nativeRect);
+  at(11500, 'transform',
+     ['', 'rotate(10 300 150)'], polyfillRect, nativeRect);
+
+  at(12000, 'transform',
+    'skewX(0)', polyfillRect, nativeRect);
+  at(12500, 'transform',
+     'skewX(10)', polyfillRect, nativeRect);
+  at(13000, 'transform',
+     'skewX(20)', polyfillRect, nativeRect);
+  at(13500, 'transform',
+     'skewX(30)', polyfillRect, nativeRect);
+
+  at(14500, 'transform',
+     'skewY(-30)', polyfillRect, nativeRect);
+  at(15000, 'transform',
+     'skewY(-20)', polyfillRect, nativeRect);
+  at(15500, 'transform',
+     'skewY(-10)', polyfillRect, nativeRect);
+
+  at(16500, 'transform', '', polyfillRect, nativeRect);
+
+}, 'animateTransform');

--- a/test/testcases/animateTransform.html
+++ b/test/testcases/animateTransform.html
@@ -8,11 +8,32 @@
 
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="500">
   <rect id="polyfillRect" width="40" height="40" fill="green">
-    <animateTransform attributeName="transform" type="scale" from="1" to="3" dur="2s"/>
+    <animateTransform attributeName="transform" type="scale" from="1" to="3" dur="2s" begin="0s" end="2s"/>
+    <animateTransform attributeName="transform" type="scale" from="3,3" to="2,4" dur="2s" begin="2s" end="4s"/>
+
+    <animateTransform attributeName="transform" type="translate" from="100" to="300" dur="2s" begin="4s" end="6s"/>
+    <animateTransform attributeName="transform" type="translate" from="300,300" to="200,400" dur="2s" begin="6s" end="8s"/>
+
+    <!-- FIXME: polyfill should support rotate with <rotate-angle> <cx> <cy> -->
+    <animateTransform attributeName="transform" type="rotate" from="0" to="40" dur="2s" begin="8s" end="10s"/>
+    <animateTransform attributeName="transform" type="rotate" from="40 0 0" to="0 400 200" dur="2s" begin="10s" end="12s"/>
+
+    <animateTransform attributeName="transform" type="skewX" from="0" to="40" dur="2s" begin="12s" end="14s"/>
+    <animateTransform attributeName="transform" type="skewY" from="-40" to="0" dur="2s" begin="14s" end="16s"/>
   </rect>
 
   <rect id="nativeRect" x="130" width="40" height="40" fill="green">
-    <nativeAnimateTransform attributeName="transform" type="scale" from="1" to="3" dur="2s"/>
+    <nativeAnimateTransform attributeName="transform" type="scale" from="1" to="3" dur="2s" begin="0s" end="2s"/>
+    <nativeAnimateTransform attributeName="transform" type="scale" from="3,3" to="2,4" dur="2s" begin="2s" end="4s"/>
+
+    <nativeAnimateTransform attributeName="transform" type="translate" from="100" to="300" dur="2s" begin="4s" end="6s"/>
+    <nativeAnimateTransform attributeName="transform" type="translate" from="300,300" to="200,400" dur="2s" begin="6s" end="8s"/>
+
+    <nativeAnimateTransform attributeName="transform" type="rotate" from="0" to="40" dur="2s" begin="8s" end="10s"/>
+    <nativeAnimateTransform attributeName="transform" type="rotate" from="40 0 0" to="0 400 200" dur="2s" begin="10s" end="12s"/>
+
+    <nativeAnimateTransform attributeName="transform" type="skewX" from="0" to="40" dur="2s" begin="12s" end="14s"/>
+    <nativeAnimateTransform attributeName="transform" type="skewY" from="-40" to="0" dur="2s" begin="14s" end="16s"/>
   </rect>
 </svg>
 


### PR DESCRIPTION
From the specification http://www.w3.org/TR/SVG/animate.html#AnimateTransformElement

  For a type="translate", each individual value is expressed as `<tx> [,<ty>]`.
  For a type="scale", each individual value is expressed as `<sx> [,<sy>]`.
  For a type="rotate", each individual value is expressed as `<rotate-angle> [<cx> <cy>]`.
  For a type="skewX" and type="skewY", each individual value is expressed as `<skew-angle>`.

`<rotate-angle> <cx> <cy>` is not currently supported by the Web Animations polyfill.
