### PR TITLE
animateTransform not specific to transform

### DIFF
--- a/smil-in-javascript.js
+++ b/smil-in-javascript.js
@@ -482,9 +482,6 @@ AnimationRecord.prototype = {
 
   createKeyframeAnimation: function() {
     var attributeName = this.attributeName;
-    if (this.nodeName === 'animateTransform') {
-      attributeName = 'transform';
-    }
 
     if (!attributeName) {
       return;


### PR DESCRIPTION
Any transform list property can be animated using animateTransform.

For example, the gradientTransform of a linearGradient element can be
animated. We don't yet support animation with defs/use, so this use case
can't be properly tested yet.
