### PR TITLE
Respond to keystrokes

### DIFF
--- a/test/testcases/keystroke-check.js
+++ b/test/testcases/keystroke-check.js
@@ -1,0 +1,26 @@
+'use strict';
+
+function issueKeystroke(charCode) {
+  var event = new Event('keypress');
+  event.charCode = charCode;
+  document.body.dispatchEvent(event);
+}
+
+function issueKeystrokes() {
+  issueKeystroke('2'.charCodeAt());
+  issueKeystroke('1'.charCodeAt());
+}
+
+timing_test(function() {
+  var polyfillAnimLeft = document.getElementById('polyfillAnimLeft');
+  var polyfillAnimRight = document.getElementById('polyfillAnimRight');
+
+  executeAt(1000, function() {
+    issueKeystrokes();
+  });
+  eventAt(1000, polyfillAnimLeft, 'begin');
+  eventAt(3000, polyfillAnimLeft, 'end');
+  eventAt(6000, polyfillAnimRight, 'begin'); // 5 second offset to keystroke
+  eventAt(8000, polyfillAnimRight, 'end');
+
+}, 'respond to keystrokes');

--- a/test/testcases/keystroke.html
+++ b/test/testcases/keystroke.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="keystroke-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="250">
+  <rect id="polyfillRectLeft" x="0" y="0" width="100" height="100" fill="blue">
+    <animate id="polyfillAnimLeft" attributeName="fill" from="red" to="red" dur="indefinite"
+        begin="accessKey(1)" end="accessKey(1) + 2s"/>
+  </rect>
+  <rect id="polyfillRectRight" x="110" y="0" width="100" height="100" fill="blue">
+    <animate id="polyfillAnimRight" attributeName="fill" from="red" to="red" dur="indefinite"
+        begin="accessKey(2) + 5s" end="accessKey(2) + 7s"/>
+  </rect>
+
+  <rect id="nativeRectLeft" x="0" y="110" width="100" height="100" fill="blue">
+    <nativeAnimate attributeName="fill" from="red" to="red" dur="indefinite"
+        begin="accessKey(1)" end="accessKey(1) + 2s"/>
+  </rect>
+  <rect id="nativeRectRight" x="110" y="110" width="100" height="100" fill="blue">
+    <nativeAnimate attributeName="fill" from="red" to="red" dur="indefinite"
+        begin="accessKey(2) + 5s" end="accessKey(2) + 7s"/>
+  </rect>
+</svg>
+
+  </body>
+</html>

--- a/test/unit-tests/parse-test.js
+++ b/test/unit-tests/parse-test.js
@@ -23,7 +23,9 @@ function matchBeginEnd(isBegin, valueStr, expectedValues) {
       isBegin, valueStr);
   assertEqual(parseResult.length, expectedValues.length);
   for (var index = 0; index < expectedValues.length; ++ index) {
-    assertEqual(parseResult[index], expectedValues[index]);
+    assertEqual(
+        JSON.stringify(parseResult[index]),
+        JSON.stringify(expectedValues[index]));
   }
 }
 
@@ -97,6 +99,14 @@ describe('parse', function() {
     it('should accept multiple values', function() {
       matchBeginEnd(true, '1ms;2ms;3ms', [1, 2, 3]);
       matchBeginEnd(false, '4ms;-5ms', [4, -5]);
+    });
+    it('should accept accessKey', function() {
+      matchBeginEnd(true, 'accessKey(1)',
+          [{accessKey: '1'.charCodeAt(), offset: 0}]);
+      matchBeginEnd(true, 'accessKey(2) + 12ms',
+          [{accessKey: '2'.charCodeAt(), offset: 12}]);
+      matchBeginEnd(false, 'accessKey(3)-9',
+          [{accessKey: '3'.charCodeAt(), offset: -9000}]);
     });
   });
 });


### PR DESCRIPTION
"Accesskey values allow an author to tie a begin or end time to a particular key press, independent of focus issues."
http://www.w3.org/TR/SMIL3/smil-timing.html#q29

begin="accessKey(1)" means the element begins when '1' is pressed.

We register a single listener on the document body when we first encounter a begin or end spec that uses accessKey.
