### PR TITLE
Register keystroke listener on documentElement

### DIFF
--- a/smil-in-javascript.js
+++ b/smil-in-javascript.js
@@ -649,7 +649,7 @@ AnimationRecord.prototype = {
         if (!accessKeyTimeValueSpecs) {
           // We were not yet listening for keypress
           accessKeyTimeValueSpecs = {};
-          document.body.addEventListener('keypress', processKeystroke);
+          document.documentElement.addEventListener('keypress', processKeystroke);
         }
         if (!accessKeyTimeValueSpecs[spec.accessKey]) {
           // We were not yet listening for spec.accessKey

--- a/test/testcases/keystroke-check.js
+++ b/test/testcases/keystroke-check.js
@@ -3,7 +3,7 @@
 function issueKeystroke(charCode) {
   var event = new Event('keypress');
   event.charCode = charCode;
-  document.body.dispatchEvent(event);
+  document.documentElement.dispatchEvent(event);
 }
 
 function issueKeystrokes() {


### PR DESCRIPTION
Use documentElement instead of document.body, as per alancutter's comment in
https://github.com/smil-in-javascript/smil-in-javascript/pull/41
