### PR TITLE
Support 'values' and 'from', 'to' in animateMotion

### DIFF
--- a/smil-in-javascript.js
+++ b/smil-in-javascript.js
@@ -673,6 +673,24 @@ AnimationRecord.prototype = {
       resolvedPath = this.path;
     }
 
+    // http://www.w3.org/TR/SVG/animate.html#AnimateMotionElement
+    // Regarding the definition of the motion path, the ‘mpath’ element
+    // overrides the ‘path’ attribute, which overrides ‘values’, which
+    // overrides ‘from’, ‘by’ and ‘to’.
+    if (!resolvedPath) {
+      // FIXME: When an mpath child is added, we should update the resolvedPath
+
+      if (this.values) {
+        var valueList = this.values.split(';');
+        resolvedPath = 'M ' + valueList.join(' L ');
+      } else {
+        // FIXME: support 'by' and optional 'from', 'to'
+        if (this.from && this.to) {
+          resolvedPath = 'M ' + this.from + ' L ' + this.to;
+        }
+      }
+    }
+
     if (verbose) {
       console.log('resolvedPath = ' + resolvedPath);
       console.log('options  = ' + JSON.stringify(this.options));

--- a/test/testcases/additive-check.js
+++ b/test/testcases/additive-check.js
@@ -1,0 +1,141 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillRect1 = document.getElementById('polyfillRect1');
+  var polyfillRect2 = document.getElementById('polyfillRect2');
+  var polyfillRect3 = document.getElementById('polyfillRect3');
+  var nativeRect1 = document.getElementById('nativeRect1');
+  var nativeRect2 = document.getElementById('nativeRect2');
+  var nativeRect3 = document.getElementById('nativeRect3');
+
+  at(0, 'transform',
+      ['translate(0, 0) rotate(0) ' +
+       'translate(0, 0) rotate(0)', undefined],
+      polyfillRect1, nativeRect1);
+  at(0, 'transform',
+      ['translate(0, 0) rotate(0) ' +
+       'translate(130, 0) rotate(0)', undefined],
+      polyfillRect2, nativeRect2);
+  at(0, 'transform',
+      ['translate(0, 0) rotate(0) ' +
+       'translate(260, 0) rotate(0)', undefined],
+      polyfillRect3, nativeRect3);
+
+  at(500, 'transform',
+      ['translate(0.000007868049578974023, 20) rotate(0) ' +
+       'translate(10, -10) rotate(0)', undefined],
+      polyfillRect1, nativeRect1);
+  at(500, 'transform',
+      ['translate(10, -10) rotate(0) ' +
+       'translate(130.00001525878906, 20) rotate(0)', undefined],
+      polyfillRect2, nativeRect2);
+  at(500, 'transform',
+      ['translate(10, -10) rotate(0) ' +
+       'translate(260, 20) rotate(0)', undefined],
+      polyfillRect3, nativeRect3);
+
+  at(1000, 'transform',
+      ['translate(0.000006993822353251744, 40) rotate(0) ' +
+       'translate(0, 0) rotate(0)', undefined],
+      polyfillRect1, nativeRect1);
+  at(1000, 'transform',
+      ['translate(0, 0) rotate(0) ' +
+       'translate(130, 40) rotate(0)', undefined],
+      polyfillRect2, nativeRect2);
+  at(1000, 'transform',
+      ['translate(0, 0) rotate(0) ' +
+       'translate(260, 40) rotate(0)', undefined],
+      polyfillRect3, nativeRect3);
+
+  at(1500, 'transform',
+      ['translate(0.000006119594218034763, 60) rotate(0) ' +
+       'translate(10, -10) rotate(0)', undefined],
+      polyfillRect1, nativeRect1);
+  at(1500, 'transform',
+      ['translate(10, -10) rotate(0) ' +
+       'translate(130, 60) rotate(0)', undefined],
+      polyfillRect2, nativeRect2);
+  at(1500, 'transform',
+      ['translate(10, -10) rotate(0) ' +
+       'translate(260, 60) rotate(0)', undefined],
+      polyfillRect3, nativeRect3);
+
+  at(2000, 'transform',
+      ['translate(0.000005245366537565133, 80) rotate(0) ' +
+       'translate(0, 0) rotate(0)', undefined],
+      polyfillRect1, nativeRect1);
+  at(2000, 'transform',
+      ['translate(0, 0) rotate(0) ' +
+       'translate(130, 80) rotate(0)', undefined],
+      polyfillRect2, nativeRect2);
+  at(2000, 'transform',
+      ['translate(0, 0) rotate(0) ' +
+       'translate(260, 80) rotate(0)', undefined],
+      polyfillRect3, nativeRect3);
+
+  at(2500, 'transform',
+      ['translate(0.000004371138857095502, 100) rotate(0) ' +
+       'translate(10, -10) rotate(0)', undefined],
+      polyfillRect1, nativeRect1);
+  at(2500, 'transform',
+      ['translate(10, -10) rotate(0) ' +
+       'translate(130, 100) rotate(0)', undefined],
+      polyfillRect2, nativeRect2);
+  at(2500, 'transform',
+      ['translate(10, -10) rotate(0) ' +
+       'translate(260, 100) rotate(0)', undefined],
+      polyfillRect3, nativeRect3);
+
+  at(3000, 'transform',
+      ['translate(0.000003496911176625872, 120) rotate(0) ' +
+       'translate(0, 0) rotate(0)', undefined],
+      polyfillRect1, nativeRect1);
+  at(3000, 'transform',
+      ['translate(0, 0) rotate(0) ' +
+       'translate(130, 120) rotate(0)', undefined],
+      polyfillRect2, nativeRect2);
+  at(3000, 'transform',
+      ['translate(0, 0) rotate(0) ' +
+       'translate(260, 120) rotate(0)', undefined],
+      polyfillRect3, nativeRect3);
+
+  at(3500, 'transform',
+      ['translate(0.0000026226832687825663, 140) rotate(0) ' +
+       'translate(10, -10) rotate(0)', undefined],
+      polyfillRect1, nativeRect1);
+  at(3500, 'transform',
+      ['translate(10, -10) rotate(0) ' +
+       'translate(130, 140) rotate(0)', undefined],
+      polyfillRect2, nativeRect2);
+  at(3500, 'transform',
+      ['translate(10, -10) rotate(0) ' +
+       'translate(260, 140) rotate(0)', undefined],
+      polyfillRect3, nativeRect3);
+
+  at(4000, 'transform',
+      ['translate(0.000001748455588312936, 160) rotate(0) ' +
+       'translate(0, 0) rotate(0)', undefined],
+      polyfillRect1, nativeRect1);
+  at(4000, 'transform',
+      ['translate(0, 0) rotate(0) ' +
+       'translate(130, 160) rotate(0)', undefined],
+      polyfillRect2, nativeRect2);
+  at(4000, 'transform',
+      ['translate(0, 0) rotate(0) ' +
+       'translate(260, 160) rotate(0)', undefined],
+      polyfillRect3, nativeRect3);
+
+  at(4500, 'transform',
+      ['translate(8.74227794156468e-7, 180) rotate(0) ' +
+       'translate(10, -10) rotate(0)', undefined],
+      polyfillRect1, nativeRect1);
+  at(4500, 'transform',
+      ['translate(10, -10) rotate(0) ' +
+       'translate(130, 180) rotate(0)', undefined],
+      polyfillRect2, nativeRect2);
+  at(4500, 'transform',
+      ['translate(10, -10) rotate(0) ' +
+       'translate(260, 180) rotate(0)', undefined],
+      polyfillRect3, nativeRect3);
+
+}, 'additive motion');

--- a/test/testcases/additive.html
+++ b/test/testcases/additive.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="additive-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="900" height="900">
+
+  <rect id="polyfillRect1" x="0" y="0" width="100" height="100" fill="green" opacity="0.5">
+    <animateMotion values="0,0 ; 0,200" dur="5s" additive="sum"/>
+    <animateMotion values="0,0; 10,-10; 0,0" dur="1s" repeatCount="5" additive="sum"/>
+  </rect>
+
+  <rect id="nativeRect1" x="0" y="0" width="100" height="100" fill="red" opacity="0.5">
+    <nativeAnimateMotion values="0,0 ; 0,200" dur="5s" additive="sum"/>
+    <nativeAnimateMotion values="0,0; 10,-10; 0,0" dur="1s" repeatCount="5" additive="sum"/>
+  </rect>
+
+  <rect id="polyfillRect2" x="130" y="0" width="100" height="100" fill="green" opacity="0.5">
+    <animateMotion values="130,0 ; 130,200" dur="5s" additive="sum"/>
+    <animateMotion values="0,0; 10,-10; 0,0" dur="1s" repeatCount="5" additive="sum"/>
+  </rect>
+
+  <rect id="nativeRect2" x="130" y="0" width="100" height="100" fill="red" opacity="0.5">
+    <nativeAnimateMotion values="130,0 ; 130,200" dur="5s" additive="sum"/>
+    <nativeAnimateMotion values="0,0; 10,-10; 0,0" dur="1s" repeatCount="5" additive="sum"/>
+  </rect>
+
+  <rect id="polyfillRect3" x="260" y="0" width="100" height="100" fill="green" opacity="0.5">
+    <animateMotion from="260,0" to="260,200" dur="5s" additive="sum"/>
+    <animateMotion values="0,0; 10,-10; 0,0" dur="1s" repeatCount="5" additive="sum"/>
+  </rect>
+
+  <rect id="nativeRect3" x="260" y="0" width="100" height="100" fill="red" opacity="0.5">
+    <nativeAnimateMotion from="260,0" to="260,200" dur="5s" additive="sum"/>
+    <nativeAnimateMotion values="0,0; 10,-10; 0,0" dur="1s" repeatCount="5" additive="sum"/>
+  </rect>
+
+</svg>
+
+  </body>
+</html>


### PR DESCRIPTION
Motion path animation using animateMotion can specify a sequence of
translates using values or from and to.

For concise testing, we make use of additive="sum" to combine the
effects of animateMotion elements on a given visual element.
