### PR TITLE
Minor code cleanup

### DIFF
--- a/smil-in-javascript.js
+++ b/smil-in-javascript.js
@@ -578,7 +578,7 @@ AnimationRecord.prototype = {
       // ignored. If the simple duration is indefinite, any ‘keyTimes’
       // specification will be ignored.
       if (this.keyTimes && this.calcMode !== 'paced' &&
-          timingInput.duration !== Infinity) {
+          this.timingInput.duration !== Infinity) {
         keyTimeList = this.keyTimes.split(';');
 
         var previousKeyTime = 0;

--- a/test/testcases/animateTransform.html
+++ b/test/testcases/animateTransform.html
@@ -14,7 +14,6 @@
     <animateTransform attributeName="transform" type="translate" from="100" to="300" dur="2s" begin="4s" end="6s"/>
     <animateTransform attributeName="transform" type="translate" from="300,300" to="200,400" dur="2s" begin="6s" end="8s"/>
 
-    <!-- FIXME: polyfill should support rotate with <rotate-angle> <cx> <cy> -->
     <animateTransform attributeName="transform" type="rotate" from="0" to="40" dur="2s" begin="8s" end="10s"/>
     <animateTransform attributeName="transform" type="rotate" from="40 0 0" to="0 400 200" dur="2s" begin="10s" end="12s"/>
 

--- a/test/testcases/composite-properties-check.js
+++ b/test/testcases/composite-properties-check.js
@@ -1,7 +1,8 @@
 'use strict';
 
 timing_test(function() {
-  var polyfillDisplacementMap = document.getElementById('polyfillDisplacementMap');
+  var polyfillDisplacementMap =
+      document.getElementById('polyfillDisplacementMap');
   var nativeDisplacementMap = document.getElementById('nativeDisplacementMap');
   var polyfillComposite = document.getElementById('polyfillComposite');
   var nativeComposite = document.getElementById('nativeComposite');

--- a/test/testcases/line-properties.html
+++ b/test/testcases/line-properties.html
@@ -25,6 +25,7 @@
     <marker id="nativeTriangle" viewBox="0 0 12 12" orient="auto">
       <path d="M 1 2 L 13 4 L 5 6 z"/>
       <nativeAnimate attributeName="refX" from="12" to="6" dur="6s" fill="freeze"/>
+      <!-- Note that native animation of refY is ignored - Chrome bug? -->
       <nativeAnimate attributeName="refY" from="6" to="0" dur="6s" fill="freeze"/>
     </marker>
   </defs>


### PR DESCRIPTION
Document that native animation of the refY is having no effect.

Remove obsolete comment that rotation should support coordinates in addition to an angle.

Address a lint error

Read a member variable instead of attempting to access a global.
