### PR TITLE
Animate SVG's offset property

### DIFF
--- a/smil-in-javascript.js
+++ b/smil-in-javascript.js
@@ -546,6 +546,13 @@ AnimationRecord.prototype = {
       return;
     }
 
+    if (attributeName === 'offset') {
+      // Web Animations uses keyframe offset for timing.
+      // When the SVG attribute 'offset' is animated, we use
+      // 'svgOffset' when communicating with Web Animations.
+      attributeName = 'svgOffset';
+    }
+
     var keyframes = null;
     if ((this.nodeName === 'animate' ||
          this.nodeName === 'animateTransform')) {

--- a/test/testcases/stop-properties-check.js
+++ b/test/testcases/stop-properties-check.js
@@ -1,0 +1,23 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillStop = document.getElementById('polyfillStop');
+  var nativeStop = document.getElementById('nativeStop');
+
+  // first animate: offset is 0.25 .. 0.3 during 0s .. 3s
+  at(0, 'offset', 0.25, polyfillStop, nativeStop);
+  at(1500, 'offset', 0.275, polyfillStop, nativeStop);
+
+  // first animate: offset is 0.3 .. 0.5 during 3s .. 4s
+  at(3000, 'offset', 0.3, polyfillStop, nativeStop);
+  at(3500, 'offset', 0.4, polyfillStop, nativeStop);
+
+  // second animate: offset is 0.5 .. 0.7 during 4s .. 5s
+  at(4000, 'offset', 0.5, polyfillStop, nativeStop);
+  at(4500, 'offset', 0.6, polyfillStop, nativeStop);
+
+  // set: offset is 0.75 from 5s onwards
+  at(5000, 'offset', 0.75, polyfillStop, nativeStop);
+  at(6000, 'offset', 0.75, polyfillStop, nativeStop);
+
+}, 'stop properties');

--- a/test/testcases/stop-properties.html
+++ b/test/testcases/stop-properties.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="stop-properties-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="250" height="250">
+
+  <defs>
+    <linearGradient id="polyfillGradient">
+      <stop offset="0" stop-color="#F00" />
+      <stop id="polyfillStop" offset="1" stop-color="#0F0">
+        <animate attributeType="XML" attributeName="offset" values="0.25;0.3;0.5" keyTimes="0;0.75;1" dur="4s"/>
+        <animate attributeType="XML" attributeName="offset" from="0.5" to="0.7" begin="4s" dur="1s"/>
+        <set attributeType="XML" attributeName="offset" to="0.75" begin="5s"/>
+      </stop>
+    </linearGradient>
+  </defs>
+
+  <rect fill="url(#polyfillGradient)" stroke="black" stroke-width="1" x="0" y="0" width="100" height="100"/>
+
+  <defs>
+    <linearGradient id="nativeGradient">
+      <stop offset="0" stop-color="#F00" />
+      <stop id="nativeStop" offset="1" stop-color="#0F0">
+        <nativeAnimate attributeType="XML" attributeName="offset" values="0.25;0.3;0.5" keyTimes="0;0.75;1" dur="4s"/>
+        <nativeAnimate attributeType="XML" attributeName="offset" from="0.5" to="0.7" begin="4s" dur="1s"/>
+        <nativeSet attributeType="XML" attributeName="offset" to="0.75" begin="5s"/>
+      </stop>
+    </linearGradient>
+  </defs>
+
+  <rect fill="url(#nativeGradient)" stroke="black" stroke-width="1" x="110" y="110" width="100" height="100"/>
+
+</svg>
+
+  </body>
+</html>

--- a/web-animations.js
+++ b/web-animations.js
@@ -2302,11 +2302,11 @@ var KeyframeInternal = function(offset, composite, easing) {
 
 KeyframeInternal.prototype = {
   addPropertyValuePair: function(property, value) {
+    if (property === 'svgOffset') {
+      property = 'offset';
+    }
     ASSERT_ENABLED && assert(!this.cssValues.hasOwnProperty(property));
     this.cssValues[property] = value;
-  },
-  hasValueForProperty: function(property) {
-    return property in this.cssValues;
   }
 };
 
@@ -4624,6 +4624,7 @@ var propertyTypes = {
   minWidth: typeWithKeywords(
       ['max-content', 'min-content', 'fill-available', 'fit-content'],
       percentLengthType),
+  offset: percentLengthType,
   opacity: numberType,
   outlineColor: typeWithKeywords(['invert'], colorType),
   outlineOffset: lengthType,
@@ -4700,6 +4701,7 @@ var svgProperties = {
   'k4': 1,
   'lightingColor': 1,
   'limitingConeAngle': 1,
+  'offset': 1,
   'pointsAtX': 1,
   'pointsAtY': 1,
   'pointsAtZ': 1,


### PR DESCRIPTION
We resolve the naming collision between Web Aniations's keyframe
'offset' and SVG's 'offset' attribute
http://www.w3.org/TR/SVG/pservers.html#StopElementOffsetAttribute
by using the name 'svgOffset' in the keyframe properties dictionary
passed to Web Animations.
