### PR TITLE
Animate SVG's offset and stroke properties

### DIFF
--- a/smil-in-javascript.js
+++ b/smil-in-javascript.js
@@ -546,6 +546,13 @@ AnimationRecord.prototype = {
       return;
     }
 
+    if (attributeName === 'offset') {
+      // Web Animations uses keyframe offset for timing.
+      // When the SVG attribute 'offset' is animated, we use
+      // 'svgOffset' when communicating with Web Animations.
+      attributeName = 'svgOffset';
+    }
+
     var keyframes = null;
     if ((this.nodeName === 'animate' ||
          this.nodeName === 'animateTransform')) {

--- a/test/testcases/circle-check.js
+++ b/test/testcases/circle-check.js
@@ -7,6 +7,7 @@ timing_test(function() {
   at(0, 'cx', 300, polyfillCircle, nativeCircle);
   at(1000, 'cy', 275, polyfillCircle, nativeCircle);
   at(2000, 'r', 150, polyfillCircle, nativeCircle);
+  at(2000, 'fill-opacity', [0.75, undefined], polyfillCircle, nativeCircle);
   at(3000, 'cx', 225, polyfillCircle, nativeCircle);
   at(3750, 'cy', 206.25, polyfillCircle, nativeCircle);
   at(3750, 'cx', 212.5, polyfillCircle, nativeCircle);

--- a/test/testcases/circle.html
+++ b/test/testcases/circle.html
@@ -12,12 +12,14 @@
     <!-- When max < min, min and max have no effect -->
     <animate attributeName="cy" from="300" to="200" dur="4s" fill="freeze" min="3.5s" max="3s"/>
     <animate attributeName="r" from="200" to="100" dur="4s" fill="freeze"/>
+    <animate attributeName="fill-opacity" from="1" to="0.5" dur="4s" fill="freeze"/>
   </circle>
 
   <circle id="nativeCircle" cx="20" cy="20" r="10" fill="red" opacity="0.5">
     <nativeAnimate attributeName="cx" from="300" to="200" dur="4s" fill="freeze" min="3s" max="3.5s"/>
     <nativeAnimate attributeName="cy" from="300" to="200" dur="4s" fill="freeze" min="3.5s" max="3s"/>
     <nativeAnimate attributeName="r" from="200" to="100" dur="4s" fill="freeze"/>
+    <nativeAnimate attributeName="fill-opacity" from="1" to="0.5" dur="4s" fill="freeze"/>
   </circle>
 </svg>
 

--- a/test/testcases/stop-properties-check.js
+++ b/test/testcases/stop-properties-check.js
@@ -1,0 +1,30 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillStop = document.getElementById('polyfillStop');
+  var nativeStop = document.getElementById('nativeStop');
+
+  // first animate: offset is 0.25 .. 0.3 during 0s .. 3s
+  at(0, 'offset', 0.25, polyfillStop, nativeStop);
+  at(1500, 'offset', 0.275, polyfillStop, nativeStop);
+
+  // first set: stop-color is blue from 2s onwards
+  at(2500, 'stop-color', ['rgba(0, 0, 128, 1)', '#0F0'],
+     polyfillStop, nativeStop);
+
+  // first animate: offset is 0.3 .. 0.5 during 3s .. 4s
+  at(3000, 'offset', 0.3, polyfillStop, nativeStop);
+  at(3500, 'offset', 0.4, polyfillStop, nativeStop);
+
+  // second animate: offset is 0.5 .. 0.7 during 4s .. 5s
+  at(4000, 'offset', 0.5, polyfillStop, nativeStop);
+  at(4500, 'offset', 0.6, polyfillStop, nativeStop);
+
+  // second set: offset is 0.75 from 5s onwards
+  at(5000, 'offset', 0.75, polyfillStop, nativeStop);
+  at(6000, 'offset', 0.75, polyfillStop, nativeStop);
+
+  // third set: stop-opacity is 0.5 from 8s onwards
+  at(8000, 'stop-opacity', [0.5, undefined], polyfillStop, nativeStop);
+
+}, 'stop properties');

--- a/test/testcases/stop-properties.html
+++ b/test/testcases/stop-properties.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="stop-properties-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="250" height="250">
+
+  <defs>
+    <linearGradient id="polyfillGradient">
+      <stop offset="0" stop-color="#F00" />
+      <stop id="polyfillStop" offset="1" stop-color="#0F0">
+        <animate attributeType="XML" attributeName="offset" values="0.25;0.3;0.5" keyTimes="0;0.75;1" dur="4s"/>
+        <set attributeType="XML" attributeName="stop-color" to="rgba(0, 0, 128, 1)" begin="2s"/>
+        <animate attributeType="XML" attributeName="offset" from="0.5" to="0.7" begin="4s" dur="1s"/>
+        <set attributeType="XML" attributeName="offset" to="0.75" begin="5s"/>
+        <set attributeType="XML" attributeName="stop-opacity" to="0.5" begin="8s"/>
+      </stop>
+    </linearGradient>
+  </defs>
+
+  <rect fill="url(#polyfillGradient)" stroke="black" stroke-width="1" x="0" y="0" width="100" height="100"/>
+
+  <defs>
+    <linearGradient id="nativeGradient">
+      <stop offset="0" stop-color="#F00" />
+      <stop id="nativeStop" offset="1" stop-color="#0F0">
+        <nativeAnimate attributeType="XML" attributeName="offset" values="0.25;0.3;0.5" keyTimes="0;0.75;1" dur="4s"/>
+        <nativeSet attributeType="XML" attributeName="stop-color" to="rgba(0, 0, 128, 1)" begin="2s"/>
+        <nativeAnimate attributeType="XML" attributeName="offset" from="0.5" to="0.7" begin="4s" dur="1s"/>
+        <nativeSet attributeType="XML" attributeName="offset" to="0.75" begin="5s"/>
+        <nativeSet attributeType="XML" attributeName="stop-opacity" to="0.5" begin="8s"/>
+      </stop>
+    </linearGradient>
+  </defs>
+
+  <rect fill="url(#nativeGradient)" stroke="black" stroke-width="1" x="110" y="110" width="100" height="100"/>
+
+</svg>
+
+  </body>
+</html>

--- a/test/testcases/stroke-properties-check.js
+++ b/test/testcases/stroke-properties-check.js
@@ -1,0 +1,23 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillLine = document.getElementById('polyfillLine');
+  var nativeLine = document.getElementById('nativeLine');
+
+  at(0, 'stroke', ['rgba(0, 0, 255, 1)', undefined], polyfillLine, nativeLine);
+  at(0, 'stroke-width', [10, undefined], polyfillLine, nativeLine);
+  at(0, 'stroke-opacity', [1, undefined], polyfillLine, nativeLine);
+  at(0, 'stroke-dashoffset', [0, undefined], polyfillLine, nativeLine);
+
+  at(1000, 'stroke', ['rgba(0, 64, 128, 1)', undefined],
+     polyfillLine, nativeLine);
+  at(1000, 'stroke-width', [15, undefined], polyfillLine, nativeLine);
+  at(1000, 'stroke-opacity', [0.6, undefined], polyfillLine, nativeLine);
+  at(1000, 'stroke-dashoffset', [50, undefined], polyfillLine, nativeLine);
+
+  at(2000, 'stroke', ['rgba(0, 128, 0, 1)', undefined],
+     polyfillLine, nativeLine);
+  at(2000, 'stroke-width', [20, undefined], polyfillLine, nativeLine);
+  at(2000, 'stroke-opacity', [0.2, undefined], polyfillLine, nativeLine);
+  at(2000, 'stroke-dashoffset', [100, undefined], polyfillLine, nativeLine);
+}, 'animate stroke properties');

--- a/test/testcases/stroke-properties.html
+++ b/test/testcases/stroke-properties.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="stroke-properties-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="800" height="250">
+
+  <!-- FIXME: we should also support animation of stroke-dasharray -->
+  <line id="polyfillLine" x1="30" y1="30" x2="730" y2="30" stroke-dasharray="10, 15, 20, 25, 30, 35">
+    <animate attributeName="stroke" from="blue" to="green" dur="2s" fill="freeze"/>
+    <animate attributeName="stroke-width" from="10" to="20" dur="2s" fill="freeze"/>
+    <animate attributeName="stroke-opacity" from="1" to="0.2" dur="2s" fill="freeze"/>
+    <animate attributeName="stroke-dashoffset" from="0" to="100" dur="2s" fill="freeze"/>
+  </line>
+
+  <line id="nativeLine" x1="30" y1="80" x2="730" y2="80" stroke-dasharray="10, 15, 20, 25, 30, 35">
+    <nativeAnimate attributeName="stroke" from="blue" to="green" dur="2s" fill="freeze"/>
+    <nativeAnimate attributeName="stroke-width" from="10" to="20" dur="2s" fill="freeze"/>
+    <nativeAnimate attributeName="stroke-opacity" from="1" to="0.2" dur="2s" fill="freeze"/>
+    <nativeAnimate attributeName="stroke-dashoffset" from="0" to="100" dur="2s" fill="freeze"/>
+  </line>
+
+</svg>
+
+  </body>
+</html>

--- a/web-animations.js
+++ b/web-animations.js
@@ -2302,11 +2302,11 @@ var KeyframeInternal = function(offset, composite, easing) {
 
 KeyframeInternal.prototype = {
   addPropertyValuePair: function(property, value) {
+    if (property === 'svgOffset') {
+      property = 'offset';
+    }
     ASSERT_ENABLED && assert(!this.cssValues.hasOwnProperty(property));
     this.cssValues[property] = value;
-  },
-  hasValueForProperty: function(property) {
-    return property in this.cssValues;
   }
 };
 
@@ -3487,6 +3487,9 @@ var colorType = typeWithKeywords(['currentColor'], {
             interp(from[2], to[2], f) / alpha, alpha];
   },
   toCssValue: function(value) {
+    if (value === undefined) {
+      return undefined;
+    }
     return 'rgba(' + Math.round(value[0]) + ', ' + Math.round(value[1]) +
         ', ' + Math.round(value[2]) + ', ' + value[3] + ')';
   },
@@ -4592,6 +4595,7 @@ var propertyTypes = {
   dy: lengthType,
   elevation: numberType,
   fill: colorType,
+  'fill-opacity': numberType,
   floodColor: colorType,
 
   // TODO: Handle these keywords properly.
@@ -4624,6 +4628,7 @@ var propertyTypes = {
   minWidth: typeWithKeywords(
       ['max-content', 'min-content', 'fill-available', 'fit-content'],
       percentLengthType),
+  offset: percentLengthType,
   opacity: numberType,
   outlineColor: typeWithKeywords(['invert'], colorType),
   outlineOffset: lengthType,
@@ -4645,8 +4650,12 @@ var propertyTypes = {
   right: percentLengthAutoType,
   scale: numberType,
   startOffset: lengthType,
-  stopColor: colorType,
+  'stop-color': colorType,
+  'stop-opacity': numberType,
   stroke: colorType,
+  'stroke-dashoffset': percentLengthType,
+  'stroke-opacity': numberType,
+  'stroke-width': percentLengthType,
   textIndent: typeWithKeywords(['each-line', 'hanging'], percentLengthType),
   textShadow: shadowType,
   top: percentLengthAutoType,
@@ -4692,6 +4701,7 @@ var svgProperties = {
   'dy': 1,
   'elevation': 1,
   'fill': 1,
+  'fill-opacity': 1,
   'floodColor': 1,
   'height': 1,
   'k1': 1,
@@ -4700,6 +4710,7 @@ var svgProperties = {
   'k4': 1,
   'lightingColor': 1,
   'limitingConeAngle': 1,
+  'offset': 1,
   'pointsAtX': 1,
   'pointsAtY': 1,
   'pointsAtZ': 1,
@@ -4710,8 +4721,12 @@ var svgProperties = {
   'ry': 1,
   'scale': 1,
   'startOffset': 1,
-  'stopColor': 1,
+  'stop-color': 1,
+  'stop-opacity': 1,
   'stroke': 1,
+  'stroke-dashoffset': 1,
+  'stroke-opacity': 1,
+  'stroke-width': 1,
   'transform': 1,
   'width': 1,
   'x': 1,


### PR DESCRIPTION
We resolve the naming collision between Web Aniations's keyframe
'offset' and SVG's 'offset' attribute
http://www.w3.org/TR/SVG/pservers.html#StopElementOffsetAttribute
by using the name 'svgOffset' in the keyframe properties dictionary
passed to Web Animations.

Note that we do not yet animate stroke-dasharray.
