### PR TITLE
Listen for all event types provided in the spec

### DIFF
--- a/test/testcases/mouseout-check.js
+++ b/test/testcases/mouseout-check.js
@@ -1,0 +1,26 @@
+'use strict';
+
+function issueMouseout(element) {
+  var event = new Event('mouseout');
+  element.dispatchEvent(event);
+}
+
+function issueClicks() {
+  var polyfillRectLeft = document.getElementById('polyfillRectLeft');
+  var polyfillRectRight = document.getElementById('polyfillRectRight');
+
+  issueMouseout(polyfillRectRight);
+  issueMouseout(polyfillRectLeft);
+}
+
+timing_test(function() {
+  var polyfillAnimLeft = document.getElementById('polyfillAnimLeft');
+  var polyfillAnimRight = document.getElementById('polyfillAnimRight');
+
+  executeAt(1000, issueClicks);
+  eventAt(1000, polyfillAnimLeft, 'begin');
+  eventAt(3000, polyfillAnimLeft, 'end');
+  eventAt(6000, polyfillAnimRight, 'begin'); // 5 second offset from mouseout
+  eventAt(8000, polyfillAnimRight, 'end');
+
+}, 'respond to mouseouts');

--- a/test/testcases/mouseout.html
+++ b/test/testcases/mouseout.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="mouseout-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="250">
+  <rect id="polyfillRectLeft" x="100" y="0" width="100" height="100" fill="blue">
+    <!-- mouseout is short for polyfillRectLeft.mouseout -->
+    <animate id="polyfillAnimLeft" attributeName="fill" from="red" to="red" dur="2s"
+        begin="mouseout"/>
+  </rect>
+  <rect id="polyfillRectRight" x="210" y="0" width="100" height="100" fill="blue">
+    <animate id="polyfillAnimRight" attributeName="fill" from="red" to="red" dur="indefinite"
+        begin="mouseout + 5s" end="mouseout + 7s"/>
+  </rect>
+
+  <rect id="nativeRectLeft" x="100" y="110" width="100" height="100" fill="blue">
+    <nativeAnimate attributeName="fill" from="red" to="red" dur="2s"
+        begin="mouseout"/>
+  </rect>
+  <rect id="nativeRectRight" x="210" y="110" width="100" height="100" fill="blue">
+    <nativeAnimate attributeName="fill" from="red" to="red" dur="indefinite"
+        begin="mouseout + 5s" end="mouseout + 7s"/>
+  </rect>
+</svg>
+
+  </body>
+</html>


### PR DESCRIPTION
Suppose the element being animated is animatedElement.
Then begin='animatedElement.mouseout' can be abbreviated to
begin='mouseout'

We can respond to animations beginning or ending by using
begin='animationElement.beginEvent' or begin='animationElement.endEvent'

Note that the response will be delayed in the main thread is busy and
the event takes time to be delivered.
