### PR TITLE
Allow space or comma separated transform values

### DIFF
--- a/smil-in-javascript.js
+++ b/smil-in-javascript.js
@@ -610,7 +610,16 @@ AnimationRecord.prototype = {
         }
 
         processValue = function(value) {
-            return transformType + '(' + value + ')';
+          // Web Animations requires scale and transform values to be comma
+          // separated.
+          // FIXME: Web Animations should also expect rotate to be comma
+          // separated
+          if (transformType === 'rotate') {
+            value = value.replace(/,/g, ' ');
+          } else {
+            value = value.trim().split(/\s*,\s*|\s+/).join(', ');
+          }
+          return transformType + '(' + value + ')';
         };
       }
 

--- a/test/testcases/animateTransform.html
+++ b/test/testcases/animateTransform.html
@@ -9,13 +9,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="500">
   <rect id="polyfillRect" width="40" height="40" fill="green">
     <animateTransform attributeName="transform" type="scale" from="1" to="3" dur="2s" begin="0s" end="2s"/>
-    <animateTransform attributeName="transform" type="scale" from="3,3" to="2,4" dur="2s" begin="2s" end="4s"/>
+    <animateTransform attributeName="transform" type="scale" from="3,3" to="2 4" dur="2s" begin="2s" end="4s"/>
 
     <animateTransform attributeName="transform" type="translate" from="100" to="300" dur="2s" begin="4s" end="6s"/>
-    <animateTransform attributeName="transform" type="translate" from="300,300" to="200,400" dur="2s" begin="6s" end="8s"/>
+    <animateTransform attributeName="transform" type="translate" from="300,300" to="200 400" dur="2s" begin="6s" end="8s"/>
 
     <animateTransform attributeName="transform" type="rotate" from="0" to="40" dur="2s" begin="8s" end="10s"/>
-    <animateTransform attributeName="transform" type="rotate" from="40 0 0" to="0 400 200" dur="2s" begin="10s" end="12s"/>
+    <animateTransform attributeName="transform" type="rotate" from="40,0,0" to="0 400 200" dur="2s" begin="10s" end="12s"/>
 
     <animateTransform attributeName="transform" type="skewX" from="0" to="40" dur="2s" begin="12s" end="14s"/>
     <animateTransform attributeName="transform" type="skewY" from="-40" to="0" dur="2s" begin="14s" end="16s"/>


### PR DESCRIPTION
Scale and translate and rotate values may be specified with spaces or commas.

We convert to using commas before forwarding to Web Animations, with one
exception to be addressed in a subsequent CL:-

Web Animations support for rotate with spaces (not commas) was added in an earlier CL. We use that for now, but it should have used commas instead.
