### PR TITLE
Animate number list properties

### DIFF
--- a/test/testcases/colorMatrix-properties-check.js
+++ b/test/testcases/colorMatrix-properties-check.js
@@ -1,0 +1,16 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillColorMatrix = document.getElementById('polyfillColorMatrix');
+  var nativeColorMatrix = document.getElementById('nativeColorMatrix');
+
+  at(0, 'values',
+     ['1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20',
+      '1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20'],
+     polyfillColorMatrix, nativeColorMatrix);
+  at(1000, 'values',
+     ['2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21',
+      '2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21'],
+     polyfillColorMatrix, nativeColorMatrix);
+
+}, 'animate values matrix');

--- a/test/testcases/colorMatrix-properties.html
+++ b/test/testcases/colorMatrix-properties.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="colorMatrix-properties-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="1100" height="900">
+
+  <filter id="polyfillFilter">
+    <feColorMatrix id="polyfillColorMatrix" type="matrix">
+      <animate attributeName="values" attributeType="XML" from="1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20" to="3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22" dur="2s"/>
+    </feColorMatrix>
+  </filter>
+  <g fill="blue" filter="url(#polyfillFilter)">
+    <rect x="10" y="10" width="490" height="580"/>
+  </g>
+
+  <filter id="nativeFilter">
+    <feColorMatrix id="nativeColorMatrix" type="matrix">
+      <nativeAnimate attributeName="values" attributeType="XML" from="1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20" to="3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22" dur="2s"/>
+    </feColorMatrix>
+  </filter>
+  <g fill="blue" filter="url(#nativeFilter)">
+    <rect x="610" y="10" width="490" height="580"/>
+  </g>
+
+</svg>
+
+  </body>
+</html>

--- a/test/testcases/spotlight-properties-check.js
+++ b/test/testcases/spotlight-properties-check.js
@@ -5,6 +5,8 @@ timing_test(function() {
   var nativeSpotLight = document.getElementById('nativeSpotLight');
   var polyfillDistantLight = document.getElementById('polyfillDistantLight');
   var nativeDistantLight = document.getElementById('nativeDistantLight');
+  var polyfillGaussianBlur = document.getElementById('polyfillGaussianBlur');
+  var nativeGaussianBlur = document.getElementById('nativeGaussianBlur');
 
   at(1000, 'z', 400, polyfillSpotLight, nativeSpotLight);
   at(2000, 'z', 300, polyfillSpotLight, nativeSpotLight);
@@ -30,5 +32,10 @@ timing_test(function() {
   at(18000, 'elevation', 60, polyfillDistantLight, nativeDistantLight);
   at(19000, 'azimuth', 45, polyfillDistantLight, nativeDistantLight);
   at(20000, 'azimuth', 90, polyfillDistantLight, nativeDistantLight);
+
+  at(21000, 'stdDeviation', ['7.625, 9.625', '7.625 9.625'],
+     polyfillGaussianBlur, nativeGaussianBlur);
+  at(22000, 'stdDeviation', ['7.75, 9.75', '7.75 9.75'],
+     polyfillGaussianBlur, nativeGaussianBlur);
 
 }, 'animate feSpotLight properties');

--- a/test/testcases/spotlight-properties.html
+++ b/test/testcases/spotlight-properties.html
@@ -19,7 +19,9 @@
       </feSpotLight>
     </feDiffuseLighting>
 
-    <feGaussianBlur in="SourceAlpha" stdDeviation="6" result="polyfillBlur"/>
+    <feGaussianBlur id="polyfillGaussianBlur" in="SourceAlpha" result="polyfillBlur">
+      <animate attributeName="stdDeviation" from="5 7" to="8 10" dur="24s" fill="freeze"/>
+    </feGaussianBlur>
     <feSpecularLighting result="polyfillSpecular" in="polyfillBlur" specularConstant="1.5" specularExponent="7" lighting-color="#0178EF">
         <feDistantLight id="polyfillDistantLight" azimuth="0" elevation="90">
           <nativeAnimate attributeName="elevation" from="90" to="30" dur="6s" begin="15s"/>
@@ -45,7 +47,9 @@
       </feSpotLight>
     </feDiffuseLighting>
 
-    <feGaussianBlur in="SourceAlpha" stdDeviation="6" result="nativeBlur"/>
+    <feGaussianBlur id="nativeGaussianBlur" in="SourceAlpha" result="nativeBlur">
+      <nativeAnimate attributeName="stdDeviation" from="5 7" to="8 10" dur="24s" fill="freeze"/>
+    </feGaussianBlur>
     <feSpecularLighting result="nativeSpecular" in="nativeBlur" specularConstant="1.5" specularExponent="7" lighting-color="#0178EF">
         <feDistantLight id="nativeDistantLight" azimuth="0" elevation="90">
           <nativeAnimate attributeName="elevation" from="90" to="30" dur="6s" begin="15s"/>

--- a/test/testcases/stroke-properties-check.js
+++ b/test/testcases/stroke-properties-check.js
@@ -10,6 +10,9 @@ timing_test(function() {
   at(0, 'stroke-dashoffset', [0, undefined], polyfillLine, nativeLine);
   at(0, 'stroke-dasharray', ['10, 15, 20, 25, 30, 35', undefined],
      polyfillLine, nativeLine);
+  at(0, 'points', ['30, 30, 730, 30, 730, 130, 30, 130',
+                   '30 30 730 30 730 130 30 130'],
+     polyfillLine, nativeLine);
 
   at(1000, 'stroke', ['rgba(0, 64, 128, 1)', undefined],
      polyfillLine, nativeLine);
@@ -18,6 +21,9 @@ timing_test(function() {
   at(1000, 'stroke-dashoffset', [50, undefined], polyfillLine, nativeLine);
   at(1000, 'stroke-dasharray', ['10, 15, 20, 30, 20, 40', undefined],
      polyfillLine, nativeLine);
+  at(1000, 'points', ['30, 80, 730, 80, 730, 180, 30, 180',
+                      '30 80 730 80 730 180 30 180'],
+     polyfillLine, nativeLine);
 
   at(2000, 'stroke', ['rgba(0, 128, 0, 1)', undefined],
      polyfillLine, nativeLine);
@@ -25,5 +31,8 @@ timing_test(function() {
   at(2000, 'stroke-opacity', [0.2, undefined], polyfillLine, nativeLine);
   at(2000, 'stroke-dashoffset', [100, undefined], polyfillLine, nativeLine);
   at(2000, 'stroke-dasharray', ['10, 15, 20, 35, 10, 45', undefined],
+     polyfillLine, nativeLine);
+  at(2000, 'points', ['30, 130, 730, 130, 730, 230, 30, 230',
+                      '30 130 730 130 730 230 30 230'],
      polyfillLine, nativeLine);
 }, 'animate stroke properties');

--- a/test/testcases/stroke-properties.html
+++ b/test/testcases/stroke-properties.html
@@ -6,23 +6,25 @@
     <script src="../harness.js"></script>
     <script src="stroke-properties-check.js"></script>
 
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="800" height="250">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="800" height="500">
 
-  <line id="polyfillLine" x1="30" y1="30" x2="730" y2="30">
+  <polyline id="polyfillLine" points="30,30 730,30 730,130 30,130" fill="none">
     <animate attributeName="stroke" from="blue" to="green" dur="2s" fill="freeze"/>
     <animate attributeName="stroke-width" from="10" to="20" dur="2s" fill="freeze"/>
     <animate attributeName="stroke-opacity" from="1" to="0.2" dur="2s" fill="freeze"/>
     <animate attributeName="stroke-dashoffset" from="0" to="100" dur="2s" fill="freeze"/>
     <animate attributeName="stroke-dasharray" from="10, 15, 20, 25, 30, 35" to="10, 15, 20, 35, 10, 45" dur="2s" fill="freeze"/>
-  </line>
+    <animate attributeName="points" from="30,30 730,30 730,130 30,130" to="30,130 730,130 730,230 30,230" dur="2s" fill="freeze"/>
+  </polyline>
 
-  <line id="nativeLine" x1="30" y1="80" x2="730" y2="80">
+  <polyline id="nativeLine" points="30,30 730,30 730,130 30,130" fill="none" transform="translate(0, 200)">
     <nativeAnimate attributeName="stroke" from="blue" to="green" dur="2s" fill="freeze"/>
     <nativeAnimate attributeName="stroke-width" from="10" to="20" dur="2s" fill="freeze"/>
     <nativeAnimate attributeName="stroke-opacity" from="1" to="0.2" dur="2s" fill="freeze"/>
     <nativeAnimate attributeName="stroke-dashoffset" from="0" to="100" dur="2s" fill="freeze"/>
     <nativeAnimate attributeName="stroke-dasharray" from="10, 15, 20, 25, 30, 35" to="10, 15, 20, 35, 10, 45" dur="2s" fill="freeze"/>
-  </line>
+    <nativeAnimate attributeName="points" from="30,30 730,30 730,130 30,130" to="30,130 730,130 730,230 30,230" dur="2s" fill="freeze"/>
+  </polyline>
 
 </svg>
 

--- a/test/testcases/text-properties-check.js
+++ b/test/testcases/text-properties-check.js
@@ -1,0 +1,9 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillText = document.getElementById('polyfillText');
+  var nativeText = document.getElementById('nativeText');
+
+  at(1000, 'dy', ['15, 20, 25', '15 20 25'], polyfillText, nativeText);
+
+}, 'text properties');

--- a/test/testcases/text-properties.html
+++ b/test/testcases/text-properties.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="text-properties-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="500" height="500">
+
+  <g>
+    <text id="polyfillText" x="10" y="10">
+      <animate attributeName="dy" attributeType="XML" dur="2s" from="0 0 0" to="30 40 50"/>
+      ABC
+    </text>
+    <text id="nativeText" x="210" y="10">
+      <nativeAnimate attributeName="dy" attributeType="XML" dur="2s" from="0 0 0" to="30 40 50"/>
+      ABC
+    </text>
+  </g>
+
+</svg>
+
+  </body>
+</html>

--- a/web-animations.js
+++ b/web-animations.js
@@ -2993,6 +2993,44 @@ var percentLengthListType = {
   }
 };
 
+var numberListType = {
+  zero: function() { return [numberType.zero()]; },
+  add: function(base, delta) {
+    var out = [];
+    var maxLength = Math.max(base.length, delta.length);
+    for (var i = 0; i < maxLength; i++) {
+      var basePosition = base[i] ? base[i] : numberType.zero();
+      var deltaPosition = delta[i] ? delta[i] : numberType.zero();
+      out.push(numberType.add(basePosition, deltaPosition));
+    }
+    return out;
+  },
+  interpolate: function(from, to, f) {
+    var out = [];
+    var maxLength = Math.max(from.length, to.length);
+    for (var i = 0; i < maxLength; i++) {
+      var fromValue = from[i] ? from[i] : numberType.zero();
+      var toValue = to[i] ? to[i] : numberType.zero();
+      out.push(numberType.interpolate(fromValue, toValue, f));
+    }
+    return out;
+  },
+  toCssValue: function(value) {
+    return value.map(numberType.toCssValue).join(', ');
+  },
+  fromCssValue: function(value) {
+    if (!isDefinedAndNotNull(value)) {
+      return undefined;
+    }
+    if (!value.trim()) {
+      return [numberType.fromCssValue('0%')];
+    }
+    var values = value.split(/\s*,\s*|\s+/);
+    var out = values.map(numberType.fromCssValue);
+    return out.every(isDefinedAndNotNull) ? out : undefined;
+  }
+};
+
 var rectangleRE = /rect\(([^,]+),([^,]+),([^,]+),([^)]+)\)/;
 var rectangleType = {
   add: function(base, delta) {
@@ -4629,8 +4667,8 @@ var propertyTypes = {
   cx: lengthType,
   cy: lengthType,
   d: pathType,
-  dx: lengthType,
-  dy: lengthType,
+  dx: percentLengthListType, // should be lengthListType
+  dy: percentLengthListType, // should be lengthListType
   elevation: numberType,
   fill: colorType,
   'fill-opacity': numberType,
@@ -4677,6 +4715,7 @@ var propertyTypes = {
   paddingTop: lengthType,
   perspective: typeWithKeywords(['none'], lengthType),
   perspectiveOrigin: originType,
+  points: numberListType,
   pointsAtX: numberType,
   pointsAtY: numberType,
   pointsAtZ: numberType,
@@ -4690,6 +4729,7 @@ var propertyTypes = {
   startOffset: lengthType,
   'stop-color': colorType,
   'stop-opacity': numberType,
+  stdDeviation: numberListType, // 1 or 2 numbers
   stroke: colorType,
   'stroke-dasharray': percentLengthListType,
   'stroke-dashoffset': percentLengthType,
@@ -4700,6 +4740,7 @@ var propertyTypes = {
   top: percentLengthAutoType,
   transform: transformType,
   transformOrigin: originType,
+  values: numberListType,
   verticalAlign: typeWithKeywords([
     'baseline',
     'sub',
@@ -4750,6 +4791,7 @@ var svgProperties = {
   'lightingColor': 1,
   'limitingConeAngle': 1,
   'offset': 1,
+  'points': 1,
   'pointsAtX': 1,
   'pointsAtY': 1,
   'pointsAtZ': 1,
@@ -4760,6 +4802,7 @@ var svgProperties = {
   'ry': 1,
   'scale': 1,
   'startOffset': 1,
+  'stdDeviation': 1,
   'stop-color': 1,
   'stop-opacity': 1,
   'stroke': 1,
@@ -4768,6 +4811,7 @@ var svgProperties = {
   'stroke-opacity': 1,
   'stroke-width': 1,
   'transform': 1,
+  'values': 1,
   'width': 1,
   'x': 1,
   'x1': 1,


### PR DESCRIPTION
The SVG attributes 'points', 'stdDeviation' and 'values' accept sequences of numbers, and can be animated.

We don't enforce restrictions on the lengths of the lists.

The properties 'dx' and 'dy' accept lists of lengths.
