### PR TITLE
Add xlink example with animate inside defs

### DIFF
--- a/test/testcases/xlink-href-check.js
+++ b/test/testcases/xlink-href-check.js
@@ -5,5 +5,7 @@ timing_test(function() {
   var nativeRect = document.getElementById('nativeRect');
 
   at(0, 'width', 200, polyfillRect, nativeRect);
-  at(10000, 'width', 200, polyfillRect, nativeRect);
-}, 'set xlink:href width');
+  at(1000, 'height', 200, polyfillRect, nativeRect);
+  at(2000, 'width', 200, polyfillRect, nativeRect);
+  at(3000, 'height', 200, polyfillRect, nativeRect);
+}, 'set xlink:href width and height');

--- a/test/testcases/xlink-href.html
+++ b/test/testcases/xlink-href.html
@@ -6,12 +6,24 @@
     <script src="../harness.js"></script>
     <script src="xlink-href-check.js"></script>
 
-<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="250">
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="500">
+
+  <defs>
+    <!-- Example with animation tags inside defs -->
+    <set xlink:href="#polyfillRect" attributeName="height" to="200"/>
+  </defs>
+
   <rect id="polyfillRect" x="0" y="0" width="100" height="100" fill="green">
   </rect>
+
+  <!-- Example with animation tags outside defs -->
   <set xlink:href="#polyfillRect" attributeName="width" to="200"/>
 
-  <rect id="nativeRect" x="0" y="110" width="100" height="100" fill="green">
+  <defs>
+    <nativeSet xlink:href="#nativeRect" attributeName="height" to="200"/>
+  </defs>
+
+  <rect id="nativeRect" x="0" y="210" width="100" height="100" fill="green">
   </rect>
   <nativeSet xlink:href="#nativeRect" attributeName="width" to="200"/>
 </svg>


### PR DESCRIPTION
When using xlink:href to specify the element being animated, the animation tags can appear anywhere in the SVG document. For example, they can appear inside a defs fragment. Some public websites use this style.
