### PR TITLE
Compare against natively paced motion

### DIFF
--- a/test/testcases/animateMotion-paced-check.js
+++ b/test/testcases/animateMotion-paced-check.js
@@ -5,31 +5,31 @@ timing_test(function() {
   var nativeRect = document.getElementById('nativeRect');
 
   at(0, 'transform',
-      'translate(0, 0) rotate(0)',
+      ['translate(0, 0) rotate(0)', undefined],
       polyfillRect, nativeRect);
 
   at(15000, 'transform',
-      'translate(15, 0) rotate(0)',
+      ['translate(15, 0) rotate(0)', undefined],
       polyfillRect, nativeRect);
 
   at(30000, 'transform',
-      'translate(30, 0) rotate(0)',
+      ['translate(30, 0) rotate(0)', undefined],
       polyfillRect, nativeRect);
 
   at(50000, 'transform',
-      'translate(30, 20) rotate(0)',
+      ['translate(30, 20) rotate(0)', undefined],
       polyfillRect, nativeRect);
 
   at(70000, 'transform',
-      'translate(30, 40) rotate(0)',
+      ['translate(30, 40) rotate(0)', undefined],
       polyfillRect, nativeRect);
 
   at(103000, 'transform',
-      'translate(63, 40) rotate(0)',
+      ['translate(63, 40) rotate(0)', undefined],
       polyfillRect, nativeRect);
 
   at(136000, 'transform',
-      'translate(96, 40) rotate(0)',
+      ['translate(96, 40) rotate(0)', undefined],
       polyfillRect, nativeRect);
 
 }, 'animateMotion paced');

--- a/test/testcases/animateMotion-paced.html
+++ b/test/testcases/animateMotion-paced.html
@@ -13,7 +13,7 @@
   </rect>
 
   <rect id="nativeRect" x="100" y="100" width="20" height="20" fill="red" opacity="0.5">
-    <animateMotion calcMode="paced" dur="136s"
+    <nativeAnimateMotion calcMode="paced" dur="136s"
       path="m 0 0 h 30 v 40 h 66" fill="freeze"/>
   </rect>
 </svg>


### PR DESCRIPTION
Correct test case animateMotion-paced.html so that one element is moved
using SMIL in JavaScript and the other element is moved using Chrome's
native SMIL implementation. Checking visually, the two elements move identically.
