### PR TITLE
Allow 'none' and 'currentColor' for stroke, fill

### DIFF
--- a/test/testcases/stroke-properties-check.js
+++ b/test/testcases/stroke-properties-check.js
@@ -4,7 +4,8 @@ timing_test(function() {
   var polyfillLine = document.getElementById('polyfillLine');
   var nativeLine = document.getElementById('nativeLine');
 
-  at(0, 'stroke', ['rgba(0, 0, 255, 1)', undefined], polyfillLine, nativeLine);
+  at(0, 'color', ['rgba(255, 0, 0, 1)', undefined], polyfillLine, nativeLine);
+  at(0, 'stroke', ['currentColor', undefined], polyfillLine, nativeLine);
   at(0, 'stroke-width', [10, undefined], polyfillLine, nativeLine);
   at(0, 'stroke-opacity', [1, undefined], polyfillLine, nativeLine);
   at(0, 'stroke-dashoffset', [0, undefined], polyfillLine, nativeLine);
@@ -14,7 +15,10 @@ timing_test(function() {
                    '30 30 730 30 730 130 30 130'],
      polyfillLine, nativeLine);
 
-  at(1000, 'stroke', ['rgba(0, 64, 128, 1)', undefined],
+  at(500, 'stroke', ['none', undefined],
+     polyfillLine, nativeLine);
+
+  at(1000, 'stroke', ['rgba(0, 128, 0, 1)', undefined],
      polyfillLine, nativeLine);
   at(1000, 'stroke-width', [15, undefined], polyfillLine, nativeLine);
   at(1000, 'stroke-opacity', [0.6, undefined], polyfillLine, nativeLine);
@@ -25,7 +29,12 @@ timing_test(function() {
                       '30 80 730 80 730 180 30 180'],
      polyfillLine, nativeLine);
 
-  at(2000, 'stroke', ['rgba(0, 128, 0, 1)', undefined],
+  at(1500, 'stroke', ['rgba(0, 0, 255, 1)', undefined],
+     polyfillLine, nativeLine);
+
+  at(2000, 'color', ['rgba(255, 255, 0, 1)', undefined],
+     polyfillLine, nativeLine);
+  at(2000, 'stroke', ['currentColor', undefined],
      polyfillLine, nativeLine);
   at(2000, 'stroke-width', [20, undefined], polyfillLine, nativeLine);
   at(2000, 'stroke-opacity', [0.2, undefined], polyfillLine, nativeLine);

--- a/test/testcases/stroke-properties.html
+++ b/test/testcases/stroke-properties.html
@@ -9,7 +9,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="800" height="500">
 
   <polyline id="polyfillLine" points="30,30 730,30 730,130 30,130" fill="none">
-    <animate attributeName="stroke" from="blue" to="green" dur="2s" fill="freeze"/>
+    <animate attributeName="color" from="red" to="yellow" dur="2s" fill="freeze"/>
+    <animate attributeName="stroke" values="currentColor; none; green; blue; currentColor" dur="2s" fill="freeze"/>
     <animate attributeName="stroke-width" from="10" to="20" dur="2s" fill="freeze"/>
     <animate attributeName="stroke-opacity" from="1" to="0.2" dur="2s" fill="freeze"/>
     <animate attributeName="stroke-dashoffset" from="0" to="100" dur="2s" fill="freeze"/>
@@ -18,7 +19,8 @@
   </polyline>
 
   <polyline id="nativeLine" points="30,30 730,30 730,130 30,130" fill="none" transform="translate(0, 200)">
-    <nativeAnimate attributeName="stroke" from="blue" to="green" dur="2s" fill="freeze"/>
+    <nativeAnimate attributeName="color" from="red" to="yellow" dur="2s" fill="freeze"/>
+    <nativeAnimate attributeName="stroke" values="currentColor; none; green; blue; currentColor" dur="2s" fill="freeze"/>
     <nativeAnimate attributeName="stroke-width" from="10" to="20" dur="2s" fill="freeze"/>
     <nativeAnimate attributeName="stroke-opacity" from="1" to="0.2" dur="2s" fill="freeze"/>
     <nativeAnimate attributeName="stroke-dashoffset" from="0" to="100" dur="2s" fill="freeze"/>

--- a/web-animations.js
+++ b/web-animations.js
@@ -3535,7 +3535,9 @@ var namedColors = {
   yellowgreen: [154, 205, 50, 1]
 };
 
-var colorType = typeWithKeywords(['currentColor'], {
+// SVG fill and stroke accept none and currentColor
+// http://www.w3.org/TR/SVG/painting.html#SpecifyingPaint
+var colorType = typeWithKeywords(['currentColor', 'none'], {
   zero: function() { return [0, 0, 0, 0]; },
   _premultiply: function(value) {
     var alpha = value[3];


### PR DESCRIPTION
'none' and 'currentColor' are valid values for the fill and stroke
attributes
http://www.w3.org/TR/SVG/painting.html#SpecifyingPaint

'currentColor' causes the color from the 'color' attribute to be used.

'none' means than no paint is applied.
