### PR TITLE
Test that no clamping occurs before interpolation

### DIFF
--- a/test/testcases/circle-check.js
+++ b/test/testcases/circle-check.js
@@ -7,8 +7,10 @@ timing_test(function() {
   at(0, 'cx', 300, polyfillCircle, nativeCircle);
   at(1000, 'cy', 275, polyfillCircle, nativeCircle);
   at(2000, 'r', 150, polyfillCircle, nativeCircle);
-  at(2000, 'fill-opacity', [0.75, undefined], polyfillCircle, nativeCircle);
+  at(2000, 'fill-opacity', [0.5, undefined], polyfillCircle, nativeCircle);
+  at(2500, 'fill-opacity', [0.75, undefined], polyfillCircle, nativeCircle);
   at(3000, 'cx', 225, polyfillCircle, nativeCircle);
+  at(3000, 'fill-opacity', [1, undefined], polyfillCircle, nativeCircle);
   at(3750, 'cy', 206.25, polyfillCircle, nativeCircle);
   at(3750, 'cx', 212.5, polyfillCircle, nativeCircle);
   at(4000, 'cy', 200, polyfillCircle, nativeCircle);

--- a/test/testcases/circle.html
+++ b/test/testcases/circle.html
@@ -12,14 +12,15 @@
     <!-- When max < min, min and max have no effect -->
     <animate attributeName="cy" from="300" to="200" dur="4s" fill="freeze" min="3.5s" max="3s"/>
     <animate attributeName="r" from="200" to="100" dur="4s" fill="freeze"/>
-    <animate attributeName="fill-opacity" from="1" to="0.5" dur="4s" fill="freeze"/>
+    <!-- Clamping occurs after interpolation -->
+    <animate attributeName="fill-opacity" values="1.5;0.5;1.5" dur="4s" fill="freeze"/>
   </circle>
 
   <circle id="nativeCircle" cx="20" cy="20" r="10" fill="red" opacity="0.5">
     <nativeAnimate attributeName="cx" from="300" to="200" dur="4s" fill="freeze" min="3s" max="3.5s"/>
     <nativeAnimate attributeName="cy" from="300" to="200" dur="4s" fill="freeze" min="3.5s" max="3s"/>
     <nativeAnimate attributeName="r" from="200" to="100" dur="4s" fill="freeze"/>
-    <nativeAnimate attributeName="fill-opacity" from="1" to="0.5" dur="4s" fill="freeze"/>
+    <nativeAnimate attributeName="fill-opacity" values="1.5;0.5;1.5" dur="4s" fill="freeze"/>
   </circle>
 </svg>
 


### PR DESCRIPTION
In the context of color, the spec encourages late clamping but does not
require it:
"User agents should clamp color values to allow color range values as
late as possible, but note that system differences might preclude
consistent behavior across different systems."
http://www.w3.org/TR/SVG/animate.html#AnimateColorElement

With opacity, nothing prevents us clamping late, after interpolation.
Use of late clamping has been observed on the public web.
