### PR TITLE
Support animation of the 'display' attribute.

### DIFF
--- a/test/testcases/values-check.js
+++ b/test/testcases/values-check.js
@@ -21,5 +21,9 @@ timing_test(function() {
   at(3500, 'width', 0, polyfillRect, nativeRect);
   at(3750, 'width', 50, polyfillRect, nativeRect);
   at(4000, 'width', 100, polyfillRect, nativeRect);
+  // Checking visually, the elements' visibility toggles.
+  at(4000, 'display', undefined, polyfillRect, nativeRect);
   at(4250, 'width', 100, polyfillRect, nativeRect);
+  at(5000, 'display', undefined, polyfillRect, nativeRect);
+  at(6000, 'display', undefined, polyfillRect, nativeRect);
 }, 'value list interpolation');

--- a/test/testcases/values.html
+++ b/test/testcases/values.html
@@ -9,10 +9,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="250">
   <rect id="polyfillRect" x="0" y="0" width="100" height="100" fill="green">
     <animate attributeName="width" values="100;0;50;0;100" dur="2s" repeatCount="2"/>
+    <animate attributeName="display" values="inline;none;inline" dur="2s" repeatCount="2" begin="4s"/>
   </rect>
 
   <rect id="nativeRect" x="0" y="110" width="100" height="100" fill="green">
     <nativeAnimate attributeName="width" values="100;0;50;0;100" dur="2s" repeatCount="2"/>
+    <nativeAnimate attributeName="display" values="inline;none;inline" dur="2s" repeatCount="2" begin="4s"/>
   </rect>
 </svg>
 

--- a/web-animations.js
+++ b/web-animations.js
@@ -4669,6 +4669,25 @@ var propertyTypes = {
   cx: lengthType,
   cy: lengthType,
   d: pathType,
+  display: typeWithKeywords([
+    'inline',
+    'block',
+    'list-item',
+    'run-in',
+    'compact',
+    'marker',
+    'table',
+    'inline-table',
+    'table-row-group',
+    'table-header-group',
+    'table-footer-group',
+    'table-row',
+    'table-column-group',
+    'table-column',
+    'table-cell',
+    'table-caption',
+    'none'
+  ], nonNumericType),
   dx: percentLengthListType, // should be lengthListType
   dy: percentLengthListType, // should be lengthListType
   elevation: numberType,


### PR DESCRIPTION
For now, we support SVG's list of display values:-

http://www.w3.org/TR/SVG/painting.html#DisplayProperty
inline | block | list-item |
run-in | compact | marker |
table | inline-table | table-row-group | table-header-group |
table-footer-group | table-row | table-column-group | table-column |
table-cell | table-caption | none

Note that CSS also defines values for display:-

http://dev.w3.org/csswg/css-box/#display
inline | block | inline-block | list-item | run-in | compact | table |
inline-table | table-row-group | table-header-group | table-footer-group
| table-row | table-column-group | table-column | table-cell |
table-caption | ruby | ruby-base | ruby-text | ruby-base-group |
ruby-text-group | container | flex | inline-flex | none

http://dev.w3.org/csswg/css-grid/#grid-containers
grid | inline-grid

http://dev.w3.org/csswg/css-flexbox/#flex-containers
flex | inline-flex

http://www.w3.org/TR/CSS2/visuren.html#display-prop
inline | block | list-item | inline-block | table | inline-table |
table-row-group | table-header-group | table-footer-group | table-row |
table-column-group | table-column | table-cell | table-caption | none
