### PR TITLE
Exercise syncbase timing using beginEvent

### DIFF
--- a/test/harness.js
+++ b/test/harness.js
@@ -208,6 +208,10 @@ function timing_test_impl(callback, desc) {
       }
       if (expectation.eventType) {
         // we wait for an event instead of a RAF
+        if (verbose) {
+          console.log('Waiting for ' + expectation.eventType + ' event on ' +
+              expectation.polyfillAnimationElement.id);
+        }
         return;
       }
       if (expectation.observeMutations) {
@@ -225,6 +229,10 @@ function timing_test_impl(callback, desc) {
 
   function registerEventListener(polyfillAnimationElement, eventType) {
     polyfillAnimationElement.addEventListener(eventType, function(e) {
+      if (verbose) {
+        console.log('Received ' + eventType + ' event on ' +
+            polyfillAnimationElement.id);
+      }
       verifyEventExpectation(eventType, e);
     });
   }

--- a/test/testcases/sync-base-event-check.js
+++ b/test/testcases/sync-base-event-check.js
@@ -1,0 +1,68 @@
+'use strict';
+
+timing_test(function() {
+  var firstPolyfillRect = document.getElementById('firstPolyfillRect');
+  var firstNativeRect = document.getElementById('firstNativeRect');
+  var secondPolyfillRect = document.getElementById('secondPolyfillRect');
+  var thirdPolyfillRect = document.getElementById('thirdPolyfillRect');
+  var fourthPolyfillRect = document.getElementById('fourthPolyfillRect');
+  var fifthPolyfillRect = document.getElementById('fifthPolyfillRect');
+
+  var firstPolyfillAnim = document.getElementById('firstPolyfillAnim');
+  var secondPolyfillAnim = document.getElementById('secondPolyfillAnim');
+  var thirdPolyfillAnim = document.getElementById('thirdPolyfillAnim');
+  var fourthPolyfillAnim = document.getElementById('fourthPolyfillAnim');
+  var fifthPolyfillAnim = document.getElementById('fifthPolyfillAnim');
+
+  eventAt(30000, firstPolyfillAnim, 'begin');
+  at(31000, 'width', 200, firstPolyfillRect, firstNativeRect);
+  at(31500, 'width', 150, firstPolyfillRect, firstNativeRect);
+  eventAt(32000, firstPolyfillAnim, 'end');
+
+  eventAt(33000, secondPolyfillAnim, 'begin');
+  // The polyfill and native animations drift out of time.
+  at(34000, 'width', 200, secondPolyfillRect, secondPolyfillRect);
+  at(34500, 'width', 150, secondPolyfillRect, secondPolyfillRect);
+  eventAt(35000, secondPolyfillAnim, 'end');
+
+  eventAt(36000, thirdPolyfillAnim, 'begin');
+  at(37000, 'width', 200, thirdPolyfillRect, thirdPolyfillRect);
+  at(37500, 'width', 150, thirdPolyfillRect, thirdPolyfillRect);
+  eventAt(38000, thirdPolyfillAnim, 'end');
+
+  eventAt(39000, fourthPolyfillAnim, 'begin');
+  at(40000, 'width', 200, fourthPolyfillRect, fourthPolyfillRect);
+  at(40500, 'width', 150, fourthPolyfillRect, fourthPolyfillRect);
+  eventAt(41000, fourthPolyfillAnim, 'end');
+
+  eventAt(42000, fifthPolyfillAnim, 'begin');
+  at(43000, 'width', 200, fifthPolyfillRect, fifthPolyfillRect);
+  at(43500, 'width', 150, fifthPolyfillRect, fifthPolyfillRect);
+  eventAt(44000, fifthPolyfillAnim, 'end');
+
+  eventAt(45000, firstPolyfillAnim, 'begin');
+  at(46000, 'width', 200, firstPolyfillRect, firstPolyfillRect);
+  at(46500, 'width', 150, firstPolyfillRect, firstPolyfillRect);
+  eventAt(47000, firstPolyfillAnim, 'end');
+
+  eventAt(48000, secondPolyfillAnim, 'begin');
+  at(49000, 'width', 200, secondPolyfillRect, secondPolyfillRect);
+  at(49500, 'width', 150, secondPolyfillRect, secondPolyfillRect);
+  eventAt(50000, secondPolyfillAnim, 'end');
+
+  eventAt(51000, thirdPolyfillAnim, 'begin');
+  at(52000, 'width', 200, thirdPolyfillRect, thirdPolyfillRect);
+  at(52500, 'width', 150, thirdPolyfillRect, thirdPolyfillRect);
+  eventAt(53000, thirdPolyfillAnim, 'end');
+
+  eventAt(54000, fourthPolyfillAnim, 'begin');
+  at(55000, 'width', 200, fourthPolyfillRect, fourthPolyfillRect);
+  at(55500, 'width', 150, fourthPolyfillRect, fourthPolyfillRect);
+  eventAt(56000, fourthPolyfillAnim, 'end');
+
+  eventAt(57000, fifthPolyfillAnim, 'begin');
+  at(58000, 'width', 200, fifthPolyfillRect, fifthPolyfillRect);
+  at(58500, 'width', 150, fifthPolyfillRect, fifthPolyfillRect);
+  eventAt(59000, fifthPolyfillAnim, 'end');
+
+}, 'sync-base dependencies using begin events');

--- a/test/testcases/sync-base-event.html
+++ b/test/testcases/sync-base-event.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="sync-base-event-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="200" height="1000">
+  <!-- We list the elements out of order, to exercise the implementation code that has handles dependent time values waiting for their timebase animation records to be created -->
+  <rect id="thirdPolyfillRect" x="0" y="200" width="100" height="90" fill="green">
+    <animate id="thirdPolyfillAnim" attributeName="width" values="100;200;100;0;0" dur="4s" begin="secondPolyfillAnim.endEvent+1s" end="secondPolyfillAnim.endEvent+3s"/>
+  </rect>
+  <rect id="fourthPolyfillRect" x="0" y="300" width="100" height="90" fill="green">
+    <animate id="fourthPolyfillAnim" attributeName="width" values="100;200;100" dur="2s" begin="secondPolyfillAnim.endEvent+4s"/>
+  </rect>
+  <rect id="fifthPolyfillRect" x="0" y="400" width="100" height="90" fill="green">
+    <animate id="fifthPolyfillAnim" attributeName="width" values="100;200;100" dur="2s" begin="fourthPolyfillAnim.beginEvent+3s" end="fourthPolyfillAnim.beginEvent+5s"/>
+  </rect>
+  <rect id="secondPolyfillRect" x="0" y="100" width="100" height="90" fill="green">
+    <animate id="secondPolyfillAnim" attributeName="width" values="100;200;100" dur="2s" begin="firstPolyfillAnim.endEvent+1s"/>
+  </rect>
+  <rect id="firstPolyfillRect" x="0" y="0" width="100" height="90" fill="green">
+    <animate id="firstPolyfillAnim" attributeName="width" values="100;200;100" dur="2s" begin="30s;fifthPolyfillAnim.endEvent+1s"/>
+  </rect>
+
+  <rect id="thirdNativeRect" x="0" y="700" width="100" height="90" fill="green">
+    <nativeAnimate id="thirdNativeAnim" attributeName="width" values="100;200;100;0;0" dur="4s" begin="secondNativeAnim.endEvent+1s" end="secondNativeAnim.endEvent+3s"/>
+  </rect>
+  <rect id="fourthNativeRect" x="0" y="800" width="100" height="90" fill="green">
+    <nativeAnimate id="fourthNativeAnim" attributeName="width" values="100;200;100" dur="2s" begin="secondNativeAnim.endEvent+4s"/>
+  </rect>
+  <rect id="fifthNativeRect" x="0" y="900" width="100" height="90" fill="green">
+    <nativeAnimate id="fifthNativeAnim" attributeName="width" values="100;200;100" dur="2s" begin="fourthNativeAnim.beginEvent+3s"/>
+  </rect>
+  <rect id="secondNativeRect" x="0" y="600" width="100" height="90" fill="green">
+    <nativeAnimate id="secondNativeAnim" attributeName="width" values="100;200;100" dur="2s" begin="firstNativeAnim.endEvent+1s"/>
+  </rect>
+  <rect id="firstNativeRect" x="0" y="500" width="100" height="90" fill="green">
+    <nativeAnimate id="firstNativeAnim" attributeName="width" values="100;200;100" dur="2s" begin="30s;fifthNativeAnim.endEvent+1s"/>
+  </rect>
+</svg>
+
+  </body>
+</html>


### PR DESCRIPTION
In SMIL begin and end attributes, animations can have their timing depend on other
animations starting by using id.beginEvent or id.begin.

The difference is that id.begin is synchronous, while id.beginEvent
waits until the main thread is processing events.

See
http://www.w3.org/TR/SMIL20/smil-timing.html#Timing-EventSensitivity
http://www.w3.org/TR/SMIL20/smil-timing.html#q134
