### PR TITLE
Hold attribute constant if values has one element

### DIFF
--- a/smil-in-javascript.js
+++ b/smil-in-javascript.js
@@ -697,6 +697,11 @@ AnimationRecord.prototype = {
           valueList.pop();
         }
 
+        if (valueList.length === 1) {
+          // We hold the value constant.
+          valueList.push(valueList[0]);
+        }
+
         // http://www.w3.org/TR/SVG/animate.html#KeyTimesAttribute
         // For animations specified with a ‘values’ list, the ‘keyTimes’
         // attribute if specified must have exactly as many values as there

--- a/test/testcases/values-check.js
+++ b/test/testcases/values-check.js
@@ -5,6 +5,7 @@ timing_test(function() {
   var nativeRect = document.getElementById('nativeRect');
 
   at(0, 'width', 100, polyfillRect, nativeRect);
+  at(0, 'height', 50, polyfillRect, nativeRect);
   at(250, 'width', 50, polyfillRect, nativeRect);
   at(500, 'width', 0, polyfillRect, nativeRect);
   at(750, 'width', 25, polyfillRect, nativeRect);
@@ -19,8 +20,10 @@ timing_test(function() {
   at(3000, 'width', 50, polyfillRect, nativeRect);
   at(3250, 'width', 25, polyfillRect, nativeRect);
   at(3500, 'width', 0, polyfillRect, nativeRect);
+  at(3500, 'height', 50, polyfillRect, nativeRect);
   at(3750, 'width', 50, polyfillRect, nativeRect);
   at(4000, 'width', 100, polyfillRect, nativeRect);
+  at(4000, 'height', 100, polyfillRect, nativeRect);
   // Checking visually, the elements' visibility toggles.
   at(4000, 'display', undefined, polyfillRect, nativeRect);
   at(4250, 'width', 100, polyfillRect, nativeRect);

--- a/test/testcases/values.html
+++ b/test/testcases/values.html
@@ -9,11 +9,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="250">
   <rect id="polyfillRect" x="0" y="0" width="100" height="100" fill="green">
     <animate attributeName="width" values="100;0;50;0;100" dur="2s" repeatCount="2"/>
+    <animate attributeName="height" values="50" keyTimes dur="2s" repeatCount="2"/>
     <animate attributeName="display" values="inline;none;inline" dur="2s" repeatCount="2" begin="4s"/>
   </rect>
 
   <rect id="nativeRect" x="0" y="110" width="100" height="100" fill="green">
     <nativeAnimate attributeName="width" values="100;0;50;0;100" dur="2s" repeatCount="2"/>
+    <nativeAnimate attributeName="height" values="50" dur="2s" repeatCount="2"/>
     <nativeAnimate attributeName="display" values="inline;none;inline" dur="2s" repeatCount="2" begin="4s"/>
   </rect>
 </svg>


### PR DESCRIPTION
When an animation element's values attribute contains only a single
entry, we use this value for the duration of the animation. (Web
Animations considers a single keyframe to be the keyframe for
offset 1 only, so we instead pass two keyframes to Web Animations.
