### PR TITLE
Code cleanup from code reviews

### DIFF
--- a/smil-in-javascript.js
+++ b/smil-in-javascript.js
@@ -862,13 +862,8 @@ AnimationRecord.prototype = {
             // FIXME: register listener when eventTarget is created
             return;
           }
-          var eventKind = spec.eventKind;
           // strip trailing Event, if present
-          if (eventKind.indexOf('Event',
-              eventKind.length - 'Event'.length) !== -1) {
-            eventKind = eventKind.substring(0,
-                eventKind.length - 'Event'.length);
-          }
+          var eventKind = spec.eventKind.replace(/Event$/, '');
           eventTarget.addEventListener(eventKind, function() {
             var currentTime = document.timeline.currentTime;
             spec.owner.addInstanceTime(currentTime + spec.offset,

--- a/test/testcases/animate-check.js
+++ b/test/testcases/animate-check.js
@@ -6,5 +6,8 @@ timing_test(function() {
 
   at(0, 'width', 200, polyfillRect, nativeRect);
   at(1500, 'width', 50, polyfillRect, nativeRect);
+  at(2000, 'fill-opacity', 0.25, polyfillRect, nativeRect);
   at(2500, 'width', 150, polyfillRect, nativeRect);
-}, 'animate width');
+  at(2500, 'fill-opacity', 0.625, polyfillRect, nativeRect);
+  at(3000, 'fill-opacity', 1, polyfillRect, nativeRect);
+}, 'animate width and opacity');

--- a/test/testcases/animate.html
+++ b/test/testcases/animate.html
@@ -9,10 +9,13 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="250">
   <rect id="polyfillRect" x="0" y="0" width="100" height="100" fill="green">
     <animate attributeName="width" from="200" to="0" dur="2s" repeatCount="indefinite"/>
+    <!-- Clamping occurs after interpolation -->
+    <animate attributeName="fill-opacity" values="1.75;0.25;1.75" dur="4s" fill="freeze"/>
   </rect>
 
-  <rect id="nativeRect" x="0" y="110" width="100" height="100" fill="green">
+  <rect id="nativeRect" x="0" y="100" width="100" height="100" fill="green">
     <nativeAnimate attributeName="width" from="200" to="0" dur="2s" repeatCount="indefinite"/>
+    <animate attributeName="fill-opacity" values="1.75;0.25;1.75" dur="4s" fill="freeze"/>
   </rect>
 </svg>
 

--- a/test/testcases/xlink-href.html
+++ b/test/testcases/xlink-href.html
@@ -7,24 +7,18 @@
     <script src="xlink-href-check.js"></script>
 
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" height="500">
+  <!-- The animation tag, e.g. set, can appear inside defs (height) or outside defs (width). -->
 
   <defs>
-    <!-- Example with animation tags inside defs -->
     <set xlink:href="#polyfillRect" attributeName="height" to="200"/>
   </defs>
-
-  <rect id="polyfillRect" x="0" y="0" width="100" height="100" fill="green">
-  </rect>
-
-  <!-- Example with animation tags outside defs -->
+  <rect id="polyfillRect" x="0" y="0" width="100" height="100" fill="green"/>
   <set xlink:href="#polyfillRect" attributeName="width" to="200"/>
 
   <defs>
     <nativeSet xlink:href="#nativeRect" attributeName="height" to="200"/>
   </defs>
-
-  <rect id="nativeRect" x="0" y="210" width="100" height="100" fill="green">
-  </rect>
+  <rect id="nativeRect" x="0" y="210" width="100" height="100" fill="green"/>
   <nativeSet xlink:href="#nativeRect" attributeName="width" to="200"/>
 </svg>
 


### PR DESCRIPTION
The test from
https://github.com/smil-in-javascript/smil-in-javascript/pull/68
has been moved to a test with adjacent rectangles, so opacity animation
can be checked visually.
