### PR TITLE
Avoid flakiness in sync-base test

### DIFF
--- a/test/testcases/sync-base-check.js
+++ b/test/testcases/sync-base-check.js
@@ -12,6 +12,7 @@ timing_test(function() {
   var fifthPolyfillRect = document.getElementById('fifthPolyfillRect');
   var fifthNativeRect = document.getElementById('fifthNativeRect');
 
+  at(0, 'width', 100, firstPolyfillRect, firstNativeRect);
   at(1000, 'width', 200, firstPolyfillRect, firstNativeRect);
   at(2000, 'width', 100, firstPolyfillRect, firstNativeRect);
   at(3000, 'width', 200, secondPolyfillRect, secondNativeRect);


### PR DESCRIPTION
The sync-base was sometimes failing with the natively animated element
not having been modified yet at the time we first checked it. Inspecting a property at the time the animation begins lets us avoid the flakes.
