### PR TITLE
Set user data directory when running layout tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tools/python/bin/*
 smil-in-javascript-4lint.js
 svg-animations.js
 test/testcases.js
+.chromium

--- a/Makefile
+++ b/Makefile
@@ -14,5 +14,5 @@ unit-test:
 layout-test:
 	touch test/testcases.js
 	-test/update-testcases.py
-	${CHROME_BIN} --user-data-dir=. test/test-runner.html
+	${CHROME_BIN} --user-data-dir=.chromium test/test-runner.html
 


### PR DESCRIPTION
The user may have a different version of Chrome from that used to run
the layout tests. We use a custom user data directory to avoid version
conflicts and warning messages.
