### PR TITLE
Support to-animation where from value is implicitly the current value

### DIFF
--- a/smil-in-javascript.js
+++ b/smil-in-javascript.js
@@ -713,7 +713,7 @@ AnimationRecord.prototype = {
           }
           keyframes.push(keyframe);
         }
-      } else if (this.from && this.to) {
+      } else {
 
         // http://www.w3.org/TR/SVG/animate.html#KeyTimesAttribute
         // For from/to/by animations, the ‘keyTimes’ attribute if specified
@@ -730,8 +730,16 @@ AnimationRecord.prototype = {
           ];
         }
 
-        keyframes[0][attributeName] = processValue(this.from);
-        keyframes[1][attributeName] = processValue(this.to);
+        if (this.from && this.to) {
+          keyframes[0][attributeName] = processValue(this.from);
+          keyframes[1][attributeName] = processValue(this.to);
+        } else if (this.to && !this.by) {
+          keyframes[1][attributeName] = processValue(this.to);
+        } else {
+          // FIXME: Support from-by animation and by animation
+          // http://www.w3.org/TR/2001/REC-smil-animation-20010904/#ByAttribute
+          keyframes = null;
+        }
       }
     } else if (this.nodeName === 'set' && this.to) {
       keyframes = [

--- a/test/testcases/animateMotion-paced-check.js
+++ b/test/testcases/animateMotion-paced-check.js
@@ -4,8 +4,8 @@ timing_test(function() {
   var polyfillRect = document.getElementById('polyfillRect');
   var nativeRect = document.getElementById('nativeRect');
 
-  var polyfillRect2 = document.getElementById('polyfillRect2');
-  var nativeRect2 = document.getElementById('nativeRect2');
+  var polyfillRectRight = document.getElementById('polyfillRectRight');
+  var nativeRectRight = document.getElementById('nativeRectRight');
 
   at(0, 'transform',
       ['translate(0, 0) rotate(0)', undefined],
@@ -13,7 +13,7 @@ timing_test(function() {
 
   at(15000, 'transform',
       ['translate(15, 0) rotate(0)', undefined],
-      polyfillRect2, nativeRect2);
+      polyfillRectRight, nativeRectRight);
 
   at(30000, 'transform',
       ['translate(30, 0) rotate(0)', undefined],
@@ -21,7 +21,7 @@ timing_test(function() {
 
   at(50000, 'transform',
       ['translate(30, 20) rotate(0)', undefined],
-      polyfillRect2, nativeRect2);
+      polyfillRectRight, nativeRectRight);
 
   at(70000, 'transform',
       ['translate(30, 40) rotate(0)', undefined],
@@ -29,7 +29,7 @@ timing_test(function() {
 
   at(103000, 'transform',
       ['translate(63, 40) rotate(0)', undefined],
-      polyfillRect2, nativeRect2);
+      polyfillRectRight, nativeRectRight);
 
   at(136000, 'transform',
       ['translate(96, 40) rotate(0)', undefined],

--- a/test/testcases/line-properties.html
+++ b/test/testcases/line-properties.html
@@ -15,10 +15,10 @@
     </marker>
   </defs>
   <line id="polyfillLine" x1="10" y1="80" x2="90" y2="20" stroke-width="5" stroke="green" opacity="0.5" marker-start="url(#polyfillTriangle)">
-    <animate attributeName="x1" from="10" to="70" dur="10s"/>
-    <animate attributeName="y1" from="80" to="60" dur="10s"/>
-    <animate attributeName="x2" from="90" to="30" dur="10s"/>
-    <animate attributeName="y2" from="20" to="40" dur="10s"/>
+    <animate attributeName="x1" to="70" dur="10s"/>
+    <animate attributeName="y1" to="60" dur="10s"/>
+    <animate attributeName="x2" to="30" dur="10s"/>
+    <animate attributeName="y2" to="40" dur="10s"/>
   </line>
 
   <defs>
@@ -30,10 +30,10 @@
     </marker>
   </defs>
   <line id="nativeLine" x1="10" y1="80" x2="90" y2="20" stroke-width="5" stroke="red" opacity="0.5" marker-end="url(#nativeTriangle)">
-    <nativeAnimate attributeName="x1" from="10" to="70" dur="10s"/>
-    <nativeAnimate attributeName="y1" from="80" to="60" dur="10s"/>
-    <nativeAnimate attributeName="x2" from="90" to="30" dur="10s"/>
-    <nativeAnimate attributeName="y2" from="20" to="40" dur="10s"/>
+    <nativeAnimate attributeName="x1" to="70" dur="10s"/>
+    <nativeAnimate attributeName="y1" to="60" dur="10s"/>
+    <nativeAnimate attributeName="x2" to="30" dur="10s"/>
+    <nativeAnimate attributeName="y2" to="40" dur="10s"/>
   </line>
 </svg>
 


### PR DESCRIPTION
to animation is described in
http://www.w3.org/TR/2001/REC-smil-animation-20010904/#AnimFuncValues
"the animation function is defined to start with the underlying value for the attribute, and finish with the value specified with the to attribute. Using this form, an author can describe an animation that will start with any current value for the attribute, and will end up at the desired to value."

Also correct test animateMotion-paced test to use correct element names.
