### PR TITLE
Hyphens and periods in ids can be escaped

### DIFF
--- a/smil-in-javascript.js
+++ b/smil-in-javascript.js
@@ -272,6 +272,15 @@ function parseOffsetValue(value) {
   var result;
 }
 
+function nonEscapedIndexOf(str, searchValue) {
+  var start = 0;
+  var index = str.indexOf(searchValue, start);
+  while (index > 0 && str[index - 1] === '\\') {
+    index = str.indexOf(searchValue, index + 1);
+  }
+  return index;
+}
+
 // Used by parseBeginEnd to implement
 // http://www.w3.org/TR/SMIL3/smil-timing.html#Timing-BeginValueListSyntax
 // Returns a TimeValueSpecification, or undefined
@@ -291,10 +300,10 @@ function parseBeginEndValue(value) {
     return Infinity;
   } else {
     var plusIndex = value.indexOf('+');
-    // FIXME: \- should be ignored when delimiting,
+    // \- is ignored when delimiting,
     // and treated as - in id or symbol
     // http://www.w3.org/TR/SMIL3/smil-timing.html#q21
-    var minusIndex = value.indexOf('-');
+    var minusIndex = nonEscapedIndexOf(value, '-');
     var offsetIndex;
     if (plusIndex === -1) {
       offsetIndex = minusIndex;
@@ -312,10 +321,10 @@ function parseBeginEndValue(value) {
       token = value.substring(0, offsetIndex).trim();
       offset = parseOffsetValue(value.substring(offsetIndex));
     }
-    // FIXME: \. should be ignored when delimiting,
+    // \. is ignored when delimiting,
     // and treated as . in id or symbol
     // http://www.w3.org/TR/SMIL3/smil-timing.html#q21
-    var separatorIndex = token.indexOf('.');
+    var separatorIndex = nonEscapedIndexOf(token, '.');
     if (separatorIndex === -1) {
       if (token.indexOf('accessKey(') === 0 &&
           token[token.length - 1] === ')') {
@@ -332,12 +341,16 @@ function parseBeginEndValue(value) {
         return undefined;
       }
     }
+    // http://www.w3.org/TR/SMIL2/smil-timing.html#Timing-SyncbaseValueSyntax
+    // http://www.w3.org/TR/SMIL2/smil-timing.html#Timing-EventValueSyntax
+    // No embedded white space is allowed between a syncbase element and a time-symbol.
+    // No embedded white space is allowed between an eventbase element and an event-symbol.
+    var id = value.substring(0, separatorIndex).replace(/\\/g, '');
     var suffix = token.substring(separatorIndex + 1);
     if (suffix !== 'begin' && suffix !== 'end' &&
         !(suffix in elementEvents)) {
       return undefined;
     }
-    var id = value.substring(0, separatorIndex);
     result = {};
     result.id = id;
     if (suffix === 'begin' || suffix === 'end') {
@@ -1249,6 +1262,7 @@ if (window['SVGPolyfillAnimationElement']) {
 }
 
 window._SmilInJavascriptTestingUtilities = {
+  _nonEscapedIndexOf: nonEscapedIndexOf,
   _parseClockValue: parseClockValue,
   _parseOffsetValue: parseOffsetValue,
   _parseBeginEndValue: parseBeginEndValue,

--- a/test/testcases/escape-punctuation-check.js
+++ b/test/testcases/escape-punctuation-check.js
@@ -1,0 +1,16 @@
+'use strict';
+
+timing_test(function() {
+  var firstPolyfillRect = document.getElementById('firstPolyfillRect');
+  var firstNativeRect = document.getElementById('firstNativeRect');
+  var secondPolyfillRect = document.getElementById('secondPolyfillRect');
+  var secondNativeRect = document.getElementById('secondNativeRect');
+  var thirdPolyfillRect = document.getElementById('thirdPolyfillRect');
+  var thirdNativeRect = document.getElementById('thirdNativeRect');
+
+  at(0, 'width', 100, firstPolyfillRect, firstNativeRect);
+  at(1000, 'width', 150, secondPolyfillRect, secondNativeRect);
+  at(2000, 'width', 200, firstPolyfillRect, firstNativeRect);
+  at(4000, 'width', 300, thirdPolyfillRect, thirdNativeRect);
+  at(5000, 'width', 350, firstPolyfillRect, firstNativeRect);
+}, 'escape punctuation in element ids');

--- a/test/testcases/escape-punctuation.html
+++ b/test/testcases/escape-punctuation.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="escape-punctuation-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="800" height="1000">
+
+  <rect id="firstPolyfillRect" x="0" y="0" width="100" height="90" fill="green" opacity="0.5">
+    <animate id="first.Polyfill-Anim" attributeName="width" values="100;400" dur="6s" begin="0s"/>
+  </rect>
+  <rect id="secondPolyfillRect" x="0" y="100" width="100" height="90" fill="green" opacity="0.5">
+    <animate id="second.Polyfill-Anim" attributeName="width" values="200;100;200" dur="4s" begin="first\.Polyfill\-Anim.begin - 2s"/>
+  </rect>
+  <rect id="thirdPolyfillRect" x="0" y="200" width="100" height="90" fill="green" opacity="0.5">
+    <animate id="third.Polyfill-Anim" attributeName="width" values="300;400" dur="2s" begin="second\.Polyfill\-Anim.end + 2s"/>
+  </rect>
+
+  <!-- Chrome, unlike Firefox, does not currently support escapes -->
+  <rect id="firstNativeRect" x="0" y="0" width="100" height="90" fill="red" opacity="0.5">
+    <nativeAnimate id="firstNativeAnim" attributeName="width" values="100;400" dur="6s" begin="0s"/>
+  </rect>
+  <rect id="secondNativeRect" x="0" y="100" width="100" height="90" fill="red" opacity="0.5">
+    <nativeAnimate id="secondNativeAnim" attributeName="width" values="200;100;200" dur="4s" begin="firstNativeAnim.begin - 2s"/>
+  </rect>
+  <rect id="thirdNativeRect" x="0" y="200" width="100" height="90" fill="red" opacity="0.5">
+    <nativeAnimate id="thirdNativeAnim" attributeName="width" values="300;400" dur="2s" begin="secondNativeAnim.end + 2s"/>
+  </rect>
+</svg>
+
+  </body>
+</html>

--- a/test/unit-tests/parse-test.js
+++ b/test/unit-tests/parse-test.js
@@ -1,5 +1,12 @@
 'use strict';
 
+function matchNonEscapedIndexOf(str, searchValue, expectedIndex) {
+  assertEqual(
+      window._SmilInJavascriptTestingUtilities._nonEscapedIndexOf(
+          str, searchValue),
+      expectedIndex);
+}
+
 function matchClockValue(valueStr, expectedValue) {
   assertEqual(
       window._SmilInJavascriptTestingUtilities._parseClockValue(valueStr),
@@ -30,6 +37,20 @@ function matchBeginEnd(isBegin, valueStr, expectedValues) {
 }
 
 describe('parse', function() {
+  describe('nonEscapedIndexOf', function() {
+    it('should return -1 when searchValue is not found', function() {
+      matchNonEscapedIndexOf('foo.begin', '-', -1);
+    });
+    it('should return -1 when searchValue is always escaped', function() {
+      matchNonEscapedIndexOf('f\\-o\\-o.begin', '-', -1);
+    });
+    it('should return index when searchValue is found', function() {
+      matchNonEscapedIndexOf('f-o-o.begin', '-', 1);
+      matchNonEscapedIndexOf('f\\-o-o.begin', '-', 4);
+      matchNonEscapedIndexOf('f-o\\-o.begin', '-', 1);
+    });
+  });
+
   describe('parseClockValue', function() {
     it('should match the supplied clock value', function() {
       matchClockValue('2h', 2 * 60 * 60 * 1000);


### PR DESCRIPTION
The begin and end attributes of SMIL animation elements can refer to other elements by id. They can also contain hyphens and periods with specific meanings: a hyphen for negative offsets, and a period before an event name.

When an element id contains a hyphen or period, that character must be
escaped using a backslash.

http://www.w3.org/TR/SMIL3/smil-timing.html#q21
