### PR TITLE
Improve clarity of animateMotion-paced test

### DIFF
--- a/test/testcases/animateMotion-paced-check.js
+++ b/test/testcases/animateMotion-paced-check.js
@@ -10,7 +10,13 @@ timing_test(function() {
   at(0, 'transform',
       ['translate(0, 0) rotate(0)', undefined],
       polyfillRect, nativeRect);
+  at(0, 'transform',
+      ['translate(0, 0) rotate(0)', undefined],
+      polyfillRectRight, nativeRectRight);
 
+  at(15000, 'transform',
+      ['translate(15, 0) rotate(0)', undefined],
+      polyfillRect, nativeRect);
   at(15000, 'transform',
       ['translate(15, 0) rotate(0)', undefined],
       polyfillRectRight, nativeRectRight);
@@ -18,7 +24,13 @@ timing_test(function() {
   at(30000, 'transform',
       ['translate(30, 0) rotate(0)', undefined],
       polyfillRect, nativeRect);
+  at(30000, 'transform',
+      ['translate(30, 0) rotate(0)', undefined],
+      polyfillRectRight, nativeRectRight);
 
+  at(50000, 'transform',
+      ['translate(30, 20) rotate(0)', undefined],
+      polyfillRect, nativeRect);
   at(50000, 'transform',
       ['translate(30, 20) rotate(0)', undefined],
       polyfillRectRight, nativeRectRight);
@@ -26,7 +38,13 @@ timing_test(function() {
   at(70000, 'transform',
       ['translate(30, 40) rotate(0)', undefined],
       polyfillRect, nativeRect);
+  at(70000, 'transform',
+      ['translate(30, 40) rotate(0)', undefined],
+      polyfillRectRight, nativeRectRight);
 
+  at(103000, 'transform',
+      ['translate(63, 40) rotate(0)', undefined],
+      polyfillRect, nativeRect);
   at(103000, 'transform',
       ['translate(63, 40) rotate(0)', undefined],
       polyfillRectRight, nativeRectRight);
@@ -34,5 +52,8 @@ timing_test(function() {
   at(136000, 'transform',
       ['translate(96, 40) rotate(0)', undefined],
       polyfillRect, nativeRect);
+  at(136000, 'transform',
+      ['translate(96, 40) rotate(0)', undefined],
+      polyfillRectRight, nativeRectRight);
 
 }, 'animateMotion paced');


### PR DESCRIPTION
We test for exactly the same behavior if the animation is 'calcMode=paced' explicitly, as we do if calcMode is not specified and so the animation is paced implicitly.
