### PR TITLE
Fall back to fillDefault when fill is not supplied

### DIFF
--- a/smil-in-javascript.js
+++ b/smil-in-javascript.js
@@ -343,8 +343,8 @@ function parseBeginEndValue(value) {
     }
     // http://www.w3.org/TR/SMIL2/smil-timing.html#Timing-SyncbaseValueSyntax
     // http://www.w3.org/TR/SMIL2/smil-timing.html#Timing-EventValueSyntax
-    // No embedded white space is allowed between a syncbase element and a time-symbol.
-    // No embedded white space is allowed between an eventbase element and an event-symbol.
+    // No white space allowed between a syncbase element and a time-symbol.
+    // No white space allowed between an eventbase element and an event-symbol.
     var id = value.substring(0, separatorIndex).replace(/\\/g, '');
     var suffix = token.substring(separatorIndex + 1);
     if (suffix !== 'begin' && suffix !== 'end' &&
@@ -521,6 +521,19 @@ AnimationRecord.prototype = {
 
     // http://www.w3.org/TR/smil/smil-timing.html#adef-fill
     // http://www.w3.org/TR/smil/smil-timing.html#adef-fillDefault
+    if (!this.fill || this.fill === 'default') {
+      var ancestor = this.element;
+      var fillDefault = ancestor.getAttribute('filldefault');
+      // Fall back to the inherited fillDefault if necessary
+      while ((!fillDefault || fillDefault === 'inherit') &&
+          ancestor.parentNode &&
+          ancestor.parentNode.getAttribute) {
+        ancestor = ancestor.parentNode;
+        fillDefault = ancestor.getAttribute('filldefault');
+      }
+
+      this.fill = fillDefault;
+    }
     if (this.fill === 'freeze' ||
         this.fill === 'hold' ||
         this.fill === 'transition' ||
@@ -530,9 +543,6 @@ AnimationRecord.prototype = {
          !this.repeatCount &&
          !this.repeatDir)) {
       timingInput.fill = 'forwards';
-
-      // FIXME: support this.fill === 'fillDefault',
-      // where we must inspect the inherited fillDefault attribute.
     }
 
     if (this.calcMode === 'paced') {

--- a/test/testcases/fillDefault-check.js
+++ b/test/testcases/fillDefault-check.js
@@ -1,0 +1,67 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillRectFF = document.getElementById('polyfillRectFF');
+  var nativeRectFF = document.getElementById('nativeRectFF');
+  var polyfillRectFR = document.getElementById('polyfillRectFR');
+  var nativeRectFR = document.getElementById('nativeRectFR');
+  var polyfillRectFD = document.getElementById('polyfillRectFD');
+  var nativeRectFD = document.getElementById('nativeRectFD');
+  var polyfillRectFU = document.getElementById('polyfillRectFU');
+  var nativeRectFU = document.getElementById('nativeRectFU');
+
+  var polyfillRectRF = document.getElementById('polyfillRectRF');
+  var nativeRectRF = document.getElementById('nativeRectRF');
+  var polyfillRectRR = document.getElementById('polyfillRectRR');
+  var nativeRectRR = document.getElementById('nativeRectRR');
+  var polyfillRectRD = document.getElementById('polyfillRectRD');
+  var nativeRectRD = document.getElementById('nativeRectRD');
+  var polyfillRectRU = document.getElementById('polyfillRectRU');
+  var nativeRectRU = document.getElementById('nativeRectRU');
+
+  var polyfillRectIF = document.getElementById('polyfillRectIF');
+  var nativeRectIF = document.getElementById('nativeRectIF');
+  var polyfillRectIR = document.getElementById('polyfillRectIR');
+  var nativeRectIR = document.getElementById('nativeRectIR');
+  var polyfillRectID = document.getElementById('polyfillRectID');
+  var nativeRectID = document.getElementById('nativeRectID');
+  var polyfillRectIU = document.getElementById('polyfillRectIU');
+  var nativeRectIU = document.getElementById('nativeRectIU');
+  var polyfillRectIAF = document.getElementById('polyfillRectIAF');
+  var nativeRectIAF = document.getElementById('nativeRectIAF');
+
+  var polyfillRectUF = document.getElementById('polyfillRectUF');
+  var nativeRectUF = document.getElementById('nativeRectUF');
+  var polyfillRectUR = document.getElementById('polyfillRectUR');
+  var nativeRectUR = document.getElementById('nativeRectUR');
+  var polyfillRectUD = document.getElementById('polyfillRectUD');
+  var nativeRectUD = document.getElementById('nativeRectUD');
+  var polyfillRectUU = document.getElementById('polyfillRectUU');
+  var nativeRectUU = document.getElementById('nativeRectUU');
+  var polyfillRectUAF = document.getElementById('polyfillRectUAF');
+  var nativeRectUAF = document.getElementById('nativeRectUAF');
+
+  at(4000, 'width', 30, polyfillRectFF, nativeRectFF);
+  at(4000, 'width', 10, polyfillRectFR, nativeRectFR);
+  // We respect fillDafault, native Chrome does not.
+  at(4000, 'width', [30, 10], polyfillRectFD, nativeRectFD);
+  at(4000, 'width', [30, 10], polyfillRectFU, nativeRectFU);
+
+  at(4000, 'width', 30, polyfillRectRF, nativeRectRF);
+  at(4000, 'width', 10, polyfillRectRR, nativeRectRR);
+  at(4000, 'width', 10, polyfillRectRD, nativeRectRD);
+  at(4000, 'width', 10, polyfillRectRU, nativeRectRU);
+
+  at(4000, 'width', 30, polyfillRectIF, nativeRectIF);
+  at(4000, 'width', 10, polyfillRectIR, nativeRectIR);
+  at(4000, 'width', 10, polyfillRectID, nativeRectID);
+  at(4000, 'width', 10, polyfillRectIU, nativeRectIU);
+  at(4000, 'width', 30, polyfillRectIAF, nativeRectIAF);
+
+  at(4000, 'width', 30, polyfillRectUF, nativeRectUF);
+  at(4000, 'width', 10, polyfillRectUR, nativeRectUR);
+  at(4000, 'width', 10, polyfillRectUD, nativeRectUD);
+  at(4000, 'width', 10, polyfillRectUU, nativeRectUU);
+  at(4000, 'width', 30, polyfillRectUAF, nativeRectUAF);
+
+}, 'fillDefault');

--- a/test/testcases/fillDefault.html
+++ b/test/testcases/fillDefault.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="fillDefault-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="190" height="70">
+  <g fillDefault="freeze">
+    <rect id="polyfillRectFF" x="0" y="0" width="10" height="10" fill="green" opacity="0.5" fillDefault="inherit">
+      <set attributeName="width" to="30" dur="1s" fill="freeze"/>
+    </rect>
+    <rect id="polyfillRectFR" x="40" y="0" width="10" height="10" fill="green" opacity="0.5" fillDefault="inherit">
+      <set attributeName="width" to="30" dur="1s" fill="remove"/>
+    </rect>
+    <rect id="polyfillRectFD" x="80" y="0" width="10" height="10" fill="green" opacity="0.5" fillDefault="inherit">
+      <set attributeName="width" to="30" dur="1s" fill="default"/>
+    </rect>
+    <rect id="polyfillRectFU" x="120" y="0" width="10" height="10" fill="green" opacity="0.5" fillDefault="inherit">
+      <set attributeName="width" to="30" dur="1s"/>
+    </rect>
+  </g>
+  <g fillDefault="remove">
+    <rect id="polyfillRectRF" x="0" y="20" width="10" height="10" fill="green" opacity="0.5" fillDefault="inherit">
+      <set attributeName="width" to="30" dur="1s" fill="freeze"/>
+    </rect>
+    <rect id="polyfillRectRR" x="40" y="20" width="10" height="10" fill="green" opacity="0.5" fillDefault="inherit">
+      <set attributeName="width" to="30" dur="1s" fill="remove"/>
+    </rect>
+    <rect id="polyfillRectRD" x="80" y="20" width="10" height="10" fill="green" opacity="0.5" fillDefault="inherit">
+      <set attributeName="width" to="30" dur="1s" fill="default"/>
+    </rect>
+    <rect id="polyfillRectRU" x="120" y="20" width="10" height="10" fill="green" opacity="0.5" fillDefault="inherit">
+      <set attributeName="width" to="30" dur="1s"/>
+    </rect>
+  </g>
+  <g fillDefault="inherit">
+    <rect id="polyfillRectIF" x="0" y="40" width="10" height="10" fill="green" opacity="0.5" fillDefault="inherit">
+      <set attributeName="width" to="30" dur="1s" fill="freeze"/>
+    </rect>
+    <rect id="polyfillRectIR" x="40" y="40" width="10" height="10" fill="green" opacity="0.5" fillDefault="inherit">
+      <set attributeName="width" to="30" dur="1s" fill="remove"/>
+    </rect>
+    <rect id="polyfillRectID" x="80" y="40" width="10" height="10" fill="green" opacity="0.5" fillDefault="inherit">
+      <set attributeName="width" to="30" dur="1s" fill="default"/>
+    </rect>
+    <rect id="polyfillRectIU" x="120" y="40" width="10" height="10" fill="green" opacity="0.5" fillDefault="inherit">
+      <set attributeName="width" to="30" dur="1s"/>
+    </rect>
+    <rect id="polyfillRectIAF" x="160" y="40" width="10" height="10" fill="green" opacity="0.5" fillDefault="inherit">
+      <set attributeName="width" to="30"/>
+    </rect>
+  </g>
+  <g>
+    <rect id="polyfillRectUF" x="0" y="60" width="10" height="10" fill="green" opacity="0.5" fillDefault="inherit">
+      <set attributeName="width" to="30" dur="1s" fill="freeze"/>
+    </rect>
+    <rect id="polyfillRectUR" x="40" y="60" width="10" height="10" fill="green" opacity="0.5" fillDefault="inherit">
+      <set attributeName="width" to="30" dur="1s" fill="remove"/>
+    </rect>
+    <rect id="polyfillRectUD" x="80" y="60" width="10" height="10" fill="green" opacity="0.5" fillDefault="inherit">
+      <set attributeName="width" to="30" dur="1s" fill="default"/>
+    </rect>
+    <rect id="polyfillRectUU" x="120" y="60" width="10" height="10" fill="green" opacity="0.5" fillDefault="inherit">
+      <set attributeName="width" to="30" dur="1s"/>
+    </rect>
+    <rect id="polyfillRectUAF" x="160" y="60" width="10" height="10" fill="green" opacity="0.5" fillDefault="inherit">
+      <set attributeName="width" to="30"/>
+    </rect>
+  </g>
+
+  <g fillDefault="freeze">
+    <rect id="nativeRectFF" x="0" y="0" width="10" height="10" fill="red" opacity="0.5" fillDefault="inherit">
+      <nativeSet attributeName="width" to="30" dur="1s" fill="freeze"/>
+    </rect>
+    <rect id="nativeRectFR" x="40" y="0" width="10" height="10" fill="red" opacity="0.5" fillDefault="inherit">
+      <nativeSet attributeName="width" to="30" dur="1s" fill="remove"/>
+    </rect>
+    <rect id="nativeRectFD" x="80" y="0" width="10" height="10" fill="red" opacity="0.5" fillDefault="inherit">
+      <nativeSet attributeName="width" to="30" dur="1s" fill="default"/>
+    </rect>
+    <rect id="nativeRectFU" x="120" y="0" width="10" height="10" fill="red" opacity="0.5" fillDefault="inherit">
+      <nativeSet attributeName="width" to="30" dur="1s"/>
+    </rect>
+  </g>
+  <g fillDefault="remove">
+    <rect id="nativeRectRF" x="0" y="20" width="10" height="10" fill="red" opacity="0.5" fillDefault="inherit">
+      <nativeSet attributeName="width" to="30" dur="1s" fill="freeze"/>
+    </rect>
+    <rect id="nativeRectRR" x="40" y="20" width="10" height="10" fill="red" opacity="0.5" fillDefault="inherit">
+      <nativeSet attributeName="width" to="30" dur="1s" fill="remove"/>
+    </rect>
+    <rect id="nativeRectRD" x="80" y="20" width="10" height="10" fill="red" opacity="0.5" fillDefault="inherit">
+      <nativeSet attributeName="width" to="30" dur="1s" fill="default"/>
+    </rect>
+    <rect id="nativeRectRU" x="120" y="20" width="10" height="10" fill="red" opacity="0.5" fillDefault="inherit">
+      <nativeSet attributeName="width" to="30" dur="1s"/>
+    </rect>
+  </g>
+  <g fillDefault="inherit">
+    <rect id="nativeRectIF" x="0" y="40" width="10" height="10" fill="red" opacity="0.5" fillDefault="inherit">
+      <nativeSet attributeName="width" to="30" dur="1s" fill="freeze"/>
+    </rect>
+    <rect id="nativeRectIR" x="40" y="40" width="10" height="10" fill="red" opacity="0.5" fillDefault="inherit">
+      <nativeSet attributeName="width" to="30" dur="1s" fill="remove"/>
+    </rect>
+    <rect id="nativeRectID" x="80" y="40" width="10" height="10" fill="red" opacity="0.5" fillDefault="inherit">
+      <nativeSet attributeName="width" to="30" dur="1s" fill="default"/>
+    </rect>
+    <rect id="nativeRectIU" x="120" y="40" width="10" height="10" fill="red" opacity="0.5" fillDefault="inherit">
+      <nativeSet attributeName="width" to="30" dur="1s"/>
+    </rect>
+    <rect id="nativeRectIAF" x="160" y="40" width="10" height="10" fill="red" opacity="0.5" fillDefault="inherit">
+      <nativeSet attributeName="width" to="30"/>
+    </rect>
+  </g>
+  <g>
+    <rect id="nativeRectUF" x="0" y="60" width="10" height="10" fill="red" opacity="0.5" fillDefault="inherit">
+      <nativeSet attributeName="width" to="30" dur="1s" fill="freeze"/>
+    </rect>
+    <rect id="nativeRectUR" x="40" y="60" width="10" height="10" fill="red" opacity="0.5" fillDefault="inherit">
+      <nativeSet attributeName="width" to="30" dur="1s" fill="remove"/>
+    </rect>
+    <rect id="nativeRectUD" x="80" y="60" width="10" height="10" fill="red" opacity="0.5" fillDefault="inherit">
+      <nativeSet attributeName="width" to="30" dur="1s" fill="default"/>
+    </rect>
+    <rect id="nativeRectUU" x="120" y="60" width="10" height="10" fill="red" opacity="0.5" fillDefault="inherit">
+      <nativeSet attributeName="width" to="30" dur="1s"/>
+    </rect>
+    <rect id="nativeRectUAF" x="160" y="60" width="10" height="10" fill="red" opacity="0.5" fillDefault="inherit">
+      <nativeSet attributeName="width" to="30"/>
+    </rect>
+  </g>
+</svg>
+
+  </body>
+</html>


### PR DESCRIPTION
fillDefault is defined in
http://www.w3.org/TR/SMIL2/smil-timing.html#adef-fillDefault

When we read the element attributes, 'fillDefault' is exposed by Chrome
as 'filldefault' (no caps)

When fill is 'default' or not supplied, we fall back to using the
(possibly inherited) fillDefault value.
