### PR TITLE
Test dynamically added set element

### DIFF
--- a/test/testcases/append-set-check.js
+++ b/test/testcases/append-set-check.js
@@ -1,0 +1,49 @@
+'use strict';
+
+function createSet(rect, setTag, attributeName, to) {
+  var attributes = {
+    attributeType: 'XML',
+    attributeName: attributeName,
+    to: to
+  };
+
+  var setElement = document.createElementNS(
+      'http://www.w3.org/2000/svg', setTag);
+  for (var name in attributes) {
+    setElement.setAttribute(name, attributes[name]);
+  }
+  rect.appendChild(setElement);
+
+  // By accessing targetElement on the newly created element,
+  // we force DOM mutations to be observed, otherwise they
+  // would not be noticed until an event was received by the
+  // mutation observer.
+  setElement.targetElement.setAttribute('stroke-width', '4');
+}
+
+function addSetHeight() {
+  var polyfillRect = document.getElementById('polyfillRect');
+  var nativeRect = document.getElementById('nativeRect');
+
+  createSet(polyfillRect, 'set', 'height', '200');
+  createSet(nativeRect, 'nativeSet', 'height', '200');
+}
+
+function addSetWidth() {
+  var polyfillRect = document.getElementById('polyfillRect');
+  var nativeRect = document.getElementById('nativeRect');
+
+  createSet(polyfillRect, 'set', 'width', '300');
+  createSet(nativeRect, 'nativeSet', 'width', '300');
+}
+
+timing_test(function() {
+  var polyfillRect = document.getElementById('polyfillRect');
+  var nativeRect = document.getElementById('nativeRect');
+
+  executeAt(1000, addSetHeight);
+  at(1000, 'height', 200, polyfillRect, nativeRect);
+  at(1000, 'stroke-width', 4, polyfillRect, nativeRect);
+  executeAt(2000, addSetWidth);
+  at(2000, 'width', 300, polyfillRect, nativeRect);
+}, 'append set');

--- a/test/testcases/append-set.html
+++ b/test/testcases/append-set.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="append-set-check.js"></script>
+
+<svg id="picture" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="500" height="500">
+  <rect id="polyfillRect" width="40" height="40" fill="green" opacity="0.5">
+  </rect>
+  <rect id="nativeRect" width="40" height="40" fill="red" opacity="0.5">
+  </rect>
+</svg>
+
+  </body>
+</html>


### PR DESCRIPTION
'set' elements can be dynamically added to the document.

FIXME: the updated width and height should be detected, even if we don't
access setElement.targetElement. Currently this access is forcing an
updateRecords.
