### PR TITLE
Support restart and restartDefault animation attributes.

### DIFF
--- a/test/testcases/restart-always-check.js
+++ b/test/testcases/restart-always-check.js
@@ -1,0 +1,29 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillRectLeft = document.getElementById('polyfillRectLeft');
+  var polyfillRectCentre = document.getElementById('polyfillRectCentre');
+  var polyfillRectRight = document.getElementById('polyfillRectRight');
+  var nativeRectLeft = document.getElementById('nativeRectLeft');
+  var nativeRectCentre = document.getElementById('nativeRectCentre');
+  var nativeRectRight = document.getElementById('nativeRectRight');
+
+  at(1000, 'width', 80, polyfillRectLeft, nativeRectLeft);
+  at(1500, 'width', 60, polyfillRectLeft, nativeRectLeft);
+  at(1500, 'width', 60, polyfillRectCentre, nativeRectCentre);
+  at(2500, 'width', 60, polyfillRectLeft, nativeRectLeft);
+  at(2500, 'width', 60, polyfillRectCentre, nativeRectCentre);
+  at(3500, 'width', 20, polyfillRectLeft, nativeRectLeft);
+  at(3500, 'width', 20, polyfillRectCentre, nativeRectCentre);
+  at(4500, 'width', 60, polyfillRectRight, nativeRectRight);
+  at(5500, 'width', 60, polyfillRectLeft, nativeRectLeft);
+  at(5500, 'width', 60, polyfillRectCentre, nativeRectCentre);
+  at(5500, 'width', 20, polyfillRectRight, nativeRectRight);
+  at(6000, 'width', 80, polyfillRectRight, nativeRectRight);
+  at(6500, 'width', 60, polyfillRectCentre, nativeRectCentre);
+  at(7500, 'width', 20, polyfillRectLeft, nativeRectLeft);
+  at(7500, 'width', 20, polyfillRectCentre, nativeRectCentre);
+  at(8500, 'width', 60, polyfillRectRight, nativeRectRight);
+  at(9500, 'width', 20, polyfillRectRight, nativeRectRight);
+
+}, 'restart always');

--- a/test/testcases/restart-always.html
+++ b/test/testcases/restart-always.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="restart-always-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="300" height="300">
+  <rect id="polyfillRectLeft" x="0" y="0" width="80" height="80" fill="green">
+    <animate id="polyfillAnimLeft" attributeName="width" from="80" to="0" dur="2s" begin="1s;2s;5s;6s" restart="always"/>
+  </rect>
+  <rect id="polyfillRectCentre" x="100" y="0" width="80" height="80" fill="green">
+    <animate attributeName="width" from="80" to="0" dur="2s" begin="polyfillAnimLeft.begin"/>
+  </rect>
+  <rect id="polyfillRectRight" x="200" y="0" width="80" height="80" fill="green">
+    <animate attributeName="width" from="80" to="0" dur="2s" begin="polyfillAnimLeft.end"/>
+  </rect>
+
+  <rect id="nativeRectLeft" x="0" y="100" width="80" height="80" fill="green">
+    <nativeAnimate id="nativeAnimLeft" attributeName="width" from="80" to="0" dur="2s" begin="1s;2s;5s;6s" restart="always"/>
+  </rect>
+  <rect id="nativeRectCentre" x="100" y="100" width="80" height="80" fill="green">
+    <nativeAnimate attributeName="width" from="80" to="0" dur="2s" begin="nativeAnimLeft.begin"/>
+  </rect>
+  <rect id="nativeRectRight" x="200" y="100" width="80" height="80" fill="green">
+    <nativeAnimate attributeName="width" from="80" to="0" dur="2s" begin="nativeAnimLeft.end"/>
+  </rect>
+</svg>
+
+  </body>
+</html>

--- a/test/testcases/restart-never-check.js
+++ b/test/testcases/restart-never-check.js
@@ -1,0 +1,31 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillRectLeft = document.getElementById('polyfillRectLeft');
+  var polyfillRectCentre = document.getElementById('polyfillRectCentre');
+  var polyfillRectRight = document.getElementById('polyfillRectRight');
+  var nativeRectLeft = document.getElementById('nativeRectLeft');
+  var nativeRectCentre = document.getElementById('nativeRectCentre');
+  var nativeRectRight = document.getElementById('nativeRectRight');
+
+  /* Unfortunately, seeking causes Chrome's native animations to reset */
+
+  at(1000, 'width', 80, polyfillRectLeft, nativeRectLeft);
+  at(1500, 'width', 60, polyfillRectLeft, nativeRectLeft);
+  at(1500, 'width', 60, polyfillRectCentre, nativeRectCentre);
+  at(2500, 'width', [20, 60], polyfillRectLeft, nativeRectLeft);
+  at(2500, 'width', [20, 60], polyfillRectCentre, nativeRectCentre);
+  at(3500, 'width', [80, 20], polyfillRectLeft, nativeRectLeft);
+  at(3500, 'width', [80, 20], polyfillRectCentre, nativeRectCentre);
+  at(4500, 'width', [80, 60], polyfillRectRight, nativeRectRight);
+  at(5500, 'width', [80, 60], polyfillRectLeft, nativeRectLeft);
+  at(5500, 'width', [80, 60], polyfillRectCentre, nativeRectCentre);
+  at(5500, 'width', [80, 20], polyfillRectRight, nativeRectRight);
+  at(6000, 'width', 80, polyfillRectRight, nativeRectRight);
+  at(6500, 'width', [80, 60], polyfillRectCentre, nativeRectCentre);
+  at(7500, 'width', [80, 20], polyfillRectLeft, nativeRectLeft);
+  at(7500, 'width', [80, 20], polyfillRectCentre, nativeRectCentre);
+  at(8500, 'width', [80, 60], polyfillRectRight, nativeRectRight);
+  at(9500, 'width', [80, 20], polyfillRectRight, nativeRectRight);
+
+}, 'restart never');

--- a/test/testcases/restart-never.html
+++ b/test/testcases/restart-never.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="restart-never-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="300" height="300">
+  <rect id="polyfillRectLeft" x="0" y="0" width="80" height="80" fill="green">
+    <animate id="polyfillAnimLeft" attributeName="width" from="80" to="0" dur="2s" begin="1s;2s;5s;6s" restart="never"/>
+  </rect>
+  <rect id="polyfillRectCentre" x="100" y="0" width="80" height="80" fill="green">
+    <animate attributeName="width" from="80" to="0" dur="2s" begin="polyfillAnimLeft.begin"/>
+  </rect>
+  <rect id="polyfillRectRight" x="200" y="0" width="80" height="80" fill="green">
+    <animate attributeName="width" from="80" to="0" dur="2s" begin="polyfillAnimLeft.end"/>
+  </rect>
+
+  <rect id="nativeRectLeft" x="0" y="100" width="80" height="80" fill="green">
+    <nativeAnimate id="nativeAnimLeft" attributeName="width" from="80" to="0" dur="2s" begin="1s;2s;5s;6s" restart="never"/>
+  </rect>
+  <rect id="nativeRectCentre" x="100" y="100" width="80" height="80" fill="green">
+    <nativeAnimate attributeName="width" from="80" to="0" dur="2s" begin="nativeAnimLeft.begin"/>
+  </rect>
+  <rect id="nativeRectRight" x="200" y="100" width="80" height="80" fill="green">
+    <nativeAnimate attributeName="width" from="80" to="0" dur="2s" begin="nativeAnimLeft.end"/>
+  </rect>
+</svg>
+
+  </body>
+</html>

--- a/test/testcases/restart-whenNotActive-check.js
+++ b/test/testcases/restart-whenNotActive-check.js
@@ -1,0 +1,31 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillRectLeft = document.getElementById('polyfillRectLeft');
+  var polyfillRectCentre = document.getElementById('polyfillRectCentre');
+  var polyfillRectRight = document.getElementById('polyfillRectRight');
+  var nativeRectLeft = document.getElementById('nativeRectLeft');
+  var nativeRectCentre = document.getElementById('nativeRectCentre');
+  var nativeRectRight = document.getElementById('nativeRectRight');
+
+  /* Unfortunately, seeking causes Chrome's native animations to reset */
+
+  at(1000, 'width', 80, polyfillRectLeft, nativeRectLeft);
+  at(1500, 'width', 60, polyfillRectLeft, nativeRectLeft);
+  at(1500, 'width', 60, polyfillRectCentre, nativeRectCentre);
+  at(2500, 'width', [20, 60], polyfillRectLeft, nativeRectLeft);
+  at(2500, 'width', [20, 60], polyfillRectCentre, nativeRectCentre);
+  at(3500, 'width', [80, 20], polyfillRectLeft, nativeRectLeft);
+  at(3500, 'width', [80, 20], polyfillRectCentre, nativeRectCentre);
+  at(4500, 'width', [80, 60], polyfillRectRight, nativeRectRight);
+  at(5500, 'width', [80, 60], polyfillRectLeft, nativeRectLeft);
+  at(5500, 'width', [80, 60], polyfillRectCentre, nativeRectCentre);
+  at(5500, 'width', [80, 20], polyfillRectRight, nativeRectRight);
+  at(6000, 'width', 80, polyfillRectRight, nativeRectRight);
+  at(6500, 'width', [80, 60], polyfillRectCentre, nativeRectCentre);
+  at(7500, 'width', [80, 20], polyfillRectLeft, nativeRectLeft);
+  at(7500, 'width', [80, 20], polyfillRectCentre, nativeRectCentre);
+  at(8500, 'width', [80, 60], polyfillRectRight, nativeRectRight);
+  at(9500, 'width', [80, 20], polyfillRectRight, nativeRectRight);
+
+}, 'restart whenNotActive');

--- a/test/testcases/restart-whenNotActive.html
+++ b/test/testcases/restart-whenNotActive.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="restart-whenNotActive-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="300" height="300">
+  <rect id="polyfillRectLeft" x="0" y="0" width="80" height="80" fill="green">
+    <animate id="polyfillAnimLeft" attributeName="width" from="80" to="0" dur="2s" begin="1s;2s;5s;6s" restart="whenNotActive"/>
+  </rect>
+  <rect id="polyfillRectCentre" x="100" y="0" width="80" height="80" fill="green">
+    <animate attributeName="width" from="80" to="0" dur="2s" begin="polyfillAnimLeft.begin"/>
+  </rect>
+  <rect id="polyfillRectRight" x="200" y="0" width="80" height="80" fill="green">
+    <animate attributeName="width" from="80" to="0" dur="2s" begin="polyfillAnimLeft.end"/>
+  </rect>
+
+  <rect id="nativeRectLeft" x="0" y="100" width="80" height="80" fill="green">
+    <nativeAnimate id="nativeAnimLeft" attributeName="width" from="80" to="0" dur="2s" begin="1s;2s;5s;6s" restart="whenNotActive"/>
+  </rect>
+  <rect id="nativeRectCentre" x="100" y="100" width="80" height="80" fill="green">
+    <nativeAnimate attributeName="width" from="80" to="0" dur="2s" begin="nativeAnimLeft.begin"/>
+  </rect>
+  <rect id="nativeRectRight" x="200" y="100" width="80" height="80" fill="green">
+    <nativeAnimate attributeName="width" from="80" to="0" dur="2s" begin="nativeAnimLeft.end"/>
+  </rect>
+</svg>
+
+  </body>
+</html>

--- a/test/testcases/restartDefault-always-check.js
+++ b/test/testcases/restartDefault-always-check.js
@@ -1,0 +1,29 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillRectLeft = document.getElementById('polyfillRectLeft');
+  var polyfillRectCentre = document.getElementById('polyfillRectCentre');
+  var polyfillRectRight = document.getElementById('polyfillRectRight');
+  var nativeRectLeft = document.getElementById('nativeRectLeft');
+  var nativeRectCentre = document.getElementById('nativeRectCentre');
+  var nativeRectRight = document.getElementById('nativeRectRight');
+
+  at(1000, 'width', 80, polyfillRectLeft, nativeRectLeft);
+  at(1500, 'width', 60, polyfillRectLeft, nativeRectLeft);
+  at(1500, 'width', 60, polyfillRectCentre, nativeRectCentre);
+  at(2500, 'width', 60, polyfillRectLeft, nativeRectLeft);
+  at(2500, 'width', 60, polyfillRectCentre, nativeRectCentre);
+  at(3500, 'width', 20, polyfillRectLeft, nativeRectLeft);
+  at(3500, 'width', 20, polyfillRectCentre, nativeRectCentre);
+  at(4500, 'width', 60, polyfillRectRight, nativeRectRight);
+  at(5500, 'width', 60, polyfillRectLeft, nativeRectLeft);
+  at(5500, 'width', 60, polyfillRectCentre, nativeRectCentre);
+  at(5500, 'width', 20, polyfillRectRight, nativeRectRight);
+  at(6000, 'width', 80, polyfillRectRight, nativeRectRight);
+  at(6500, 'width', 60, polyfillRectCentre, nativeRectCentre);
+  at(7500, 'width', 20, polyfillRectLeft, nativeRectLeft);
+  at(7500, 'width', 20, polyfillRectCentre, nativeRectCentre);
+  at(8500, 'width', 60, polyfillRectRight, nativeRectRight);
+  at(9500, 'width', 20, polyfillRectRight, nativeRectRight);
+
+}, 'restartDefault always');

--- a/test/testcases/restartDefault-always.html
+++ b/test/testcases/restartDefault-always.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="restartDefault-always-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="300" height="300">
+  <rect id="polyfillRectLeft" x="0" y="0" width="80" height="80" fill="green" restartDefault="always">
+    <animate id="polyfillAnimLeft" attributeName="width" from="80" to="0" dur="2s" begin="1s;2s;5s;6s"/>
+  </rect>
+  <rect id="polyfillRectCentre" x="100" y="0" width="80" height="80" fill="green">
+    <animate attributeName="width" from="80" to="0" dur="2s" begin="polyfillAnimLeft.begin"/>
+  </rect>
+  <rect id="polyfillRectRight" x="200" y="0" width="80" height="80" fill="green">
+    <animate attributeName="width" from="80" to="0" dur="2s" begin="polyfillAnimLeft.end"/>
+  </rect>
+
+  <rect id="nativeRectLeft" x="0" y="100" width="80" height="80" fill="green" restartDefault="always">
+    <nativeAnimate id="nativeAnimLeft" attributeName="width" from="80" to="0" dur="2s" begin="1s;2s;5s;6s"/>
+  </rect>
+  <rect id="nativeRectCentre" x="100" y="100" width="80" height="80" fill="green">
+    <nativeAnimate attributeName="width" from="80" to="0" dur="2s" begin="nativeAnimLeft.begin"/>
+  </rect>
+  <rect id="nativeRectRight" x="200" y="100" width="80" height="80" fill="green">
+    <nativeAnimate attributeName="width" from="80" to="0" dur="2s" begin="nativeAnimLeft.end"/>
+  </rect>
+</svg>
+
+  </body>
+</html>

--- a/test/testcases/restartDefault-never-check.js
+++ b/test/testcases/restartDefault-never-check.js
@@ -1,0 +1,31 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillRectLeft = document.getElementById('polyfillRectLeft');
+  var polyfillRectCentre = document.getElementById('polyfillRectCentre');
+  var polyfillRectRight = document.getElementById('polyfillRectRight');
+  var nativeRectLeft = document.getElementById('nativeRectLeft');
+  var nativeRectCentre = document.getElementById('nativeRectCentre');
+  var nativeRectRight = document.getElementById('nativeRectRight');
+
+  /* Unfortunately, seeking causes Chrome's native animations to reset */
+
+  at(1000, 'width', 80, polyfillRectLeft, nativeRectLeft);
+  at(1500, 'width', 60, polyfillRectLeft, nativeRectLeft);
+  at(1500, 'width', 60, polyfillRectCentre, nativeRectCentre);
+  at(2500, 'width', [20, 60], polyfillRectLeft, nativeRectLeft);
+  at(2500, 'width', [20, 60], polyfillRectCentre, nativeRectCentre);
+  at(3500, 'width', [80, 20], polyfillRectLeft, nativeRectLeft);
+  at(3500, 'width', [80, 20], polyfillRectCentre, nativeRectCentre);
+  at(4500, 'width', [80, 60], polyfillRectRight, nativeRectRight);
+  at(5500, 'width', [80, 60], polyfillRectLeft, nativeRectLeft);
+  at(5500, 'width', [80, 60], polyfillRectCentre, nativeRectCentre);
+  at(5500, 'width', [80, 20], polyfillRectRight, nativeRectRight);
+  at(6000, 'width', 80, polyfillRectRight, nativeRectRight);
+  at(6500, 'width', [80, 60], polyfillRectCentre, nativeRectCentre);
+  at(7500, 'width', [80, 20], polyfillRectLeft, nativeRectLeft);
+  at(7500, 'width', [80, 20], polyfillRectCentre, nativeRectCentre);
+  at(8500, 'width', [80, 60], polyfillRectRight, nativeRectRight);
+  at(9500, 'width', [80, 20], polyfillRectRight, nativeRectRight);
+
+}, 'restartDefault never');

--- a/test/testcases/restartDefault-never.html
+++ b/test/testcases/restartDefault-never.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="restartDefault-never-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="300" height="300">
+  <rect id="polyfillRectLeft" x="0" y="0" width="80" height="80" fill="green" restartDefault="never">
+    <animate id="polyfillAnimLeft" attributeName="width" from="80" to="0" dur="2s" begin="1s;2s;5s;6s"/>
+  </rect>
+  <rect id="polyfillRectCentre" x="100" y="0" width="80" height="80" fill="green">
+    <animate attributeName="width" from="80" to="0" dur="2s" begin="polyfillAnimLeft.begin"/>
+  </rect>
+  <rect id="polyfillRectRight" x="200" y="0" width="80" height="80" fill="green">
+    <animate attributeName="width" from="80" to="0" dur="2s" begin="polyfillAnimLeft.end"/>
+  </rect>
+
+  <rect id="nativeRectLeft" x="0" y="100" width="80" height="80" fill="green" restartDefault="never">
+    <nativeAnimate id="nativeAnimLeft" attributeName="width" from="80" to="0" dur="2s" begin="1s;2s;5s;6s"/>
+  </rect>
+  <rect id="nativeRectCentre" x="100" y="100" width="80" height="80" fill="green">
+    <nativeAnimate attributeName="width" from="80" to="0" dur="2s" begin="nativeAnimLeft.begin"/>
+  </rect>
+  <rect id="nativeRectRight" x="200" y="100" width="80" height="80" fill="green">
+    <nativeAnimate attributeName="width" from="80" to="0" dur="2s" begin="nativeAnimLeft.end"/>
+  </rect>
+</svg>
+
+  </body>
+</html>

--- a/test/testcases/restartDefault-whenNotActive-check.js
+++ b/test/testcases/restartDefault-whenNotActive-check.js
@@ -1,0 +1,31 @@
+'use strict';
+
+timing_test(function() {
+  var polyfillRectLeft = document.getElementById('polyfillRectLeft');
+  var polyfillRectCentre = document.getElementById('polyfillRectCentre');
+  var polyfillRectRight = document.getElementById('polyfillRectRight');
+  var nativeRectLeft = document.getElementById('nativeRectLeft');
+  var nativeRectCentre = document.getElementById('nativeRectCentre');
+  var nativeRectRight = document.getElementById('nativeRectRight');
+
+  /* Unfortunately, seeking causes Chrome's native animations to reset */
+
+  at(1000, 'width', 80, polyfillRectLeft, nativeRectLeft);
+  at(1500, 'width', 60, polyfillRectLeft, nativeRectLeft);
+  at(1500, 'width', 60, polyfillRectCentre, nativeRectCentre);
+  at(2500, 'width', [20, 60], polyfillRectLeft, nativeRectLeft);
+  at(2500, 'width', [20, 60], polyfillRectCentre, nativeRectCentre);
+  at(3500, 'width', [80, 20], polyfillRectLeft, nativeRectLeft);
+  at(3500, 'width', [80, 20], polyfillRectCentre, nativeRectCentre);
+  at(4500, 'width', [80, 60], polyfillRectRight, nativeRectRight);
+  at(5500, 'width', [80, 60], polyfillRectLeft, nativeRectLeft);
+  at(5500, 'width', [80, 60], polyfillRectCentre, nativeRectCentre);
+  at(5500, 'width', [80, 20], polyfillRectRight, nativeRectRight);
+  at(6000, 'width', 80, polyfillRectRight, nativeRectRight);
+  at(6500, 'width', [80, 60], polyfillRectCentre, nativeRectCentre);
+  at(7500, 'width', [80, 20], polyfillRectLeft, nativeRectLeft);
+  at(7500, 'width', [80, 20], polyfillRectCentre, nativeRectCentre);
+  at(8500, 'width', [80, 60], polyfillRectRight, nativeRectRight);
+  at(9500, 'width', [80, 20], polyfillRectRight, nativeRectRight);
+
+}, 'restartDefault whenNotActive');

--- a/test/testcases/restartDefault-whenNotActive.html
+++ b/test/testcases/restartDefault-whenNotActive.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html>
+  <body>
+    <script src="../../web-animations.js"></script>
+    <script src="../../smil-in-javascript.js"></script>
+    <script src="../harness.js"></script>
+    <script src="restartDefault-whenNotActive-check.js"></script>
+
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="300" height="300" restartDefault="whenNotActive">
+  <rect id="polyfillRectLeft" x="0" y="0" width="80" height="80" fill="green">
+    <animate id="polyfillAnimLeft" attributeName="width" from="80" to="0" dur="2s" begin="1s;2s;5s;6s"/>
+  </rect>
+  <rect id="polyfillRectCentre" x="100" y="0" width="80" height="80" fill="green">
+    <animate attributeName="width" from="80" to="0" dur="2s" begin="polyfillAnimLeft.begin"/>
+  </rect>
+  <rect id="polyfillRectRight" x="200" y="0" width="80" height="80" fill="green">
+    <animate attributeName="width" from="80" to="0" dur="2s" begin="polyfillAnimLeft.end"/>
+  </rect>
+
+  <rect id="nativeRectLeft" x="0" y="100" width="80" height="80" fill="green" restartDefault="whenNotActive">
+    <nativeAnimate id="nativeAnimLeft" attributeName="width" from="80" to="0" dur="2s" begin="1s;2s;5s;6s"/>
+  </rect>
+  <rect id="nativeRectCentre" x="100" y="100" width="80" height="80" fill="green">
+    <nativeAnimate attributeName="width" from="80" to="0" dur="2s" begin="nativeAnimLeft.begin"/>
+  </rect>
+  <rect id="nativeRectRight" x="200" y="100" width="80" height="80" fill="green">
+    <nativeAnimate attributeName="width" from="80" to="0" dur="2s" begin="nativeAnimLeft.end"/>
+  </rect>
+</svg>
+
+  </body>
+</html>


### PR DESCRIPTION
The 'restart' attribute can be used to prevent an animation from beginning if it has previously begun (restart never) or it is currently running (restart whenNotActive)

The (possibly inherited) 'restartDefault' attribute is used when the 'restart' attribute is not supplied.

http://www.w3.org/TR/smil/smil-timing.html#adef-restart
http://www.w3.org/TR/smil/smil-timing.html#adef-restartDefault
