### PR TITLE
Consistently compare with nativeAnimate

### DIFF
--- a/test/testcases/animate-check.js
+++ b/test/testcases/animate-check.js
@@ -6,8 +6,9 @@ timing_test(function() {
 
   at(0, 'width', 200, polyfillRect, nativeRect);
   at(1500, 'width', 50, polyfillRect, nativeRect);
-  at(2000, 'fill-opacity', 0.25, polyfillRect, nativeRect);
+  // Chrome's native SMIL doesn't animate fill-opacity
+  at(2000, 'fill-opacity', [0.25, undefined], polyfillRect, nativeRect);
   at(2500, 'width', 150, polyfillRect, nativeRect);
-  at(2500, 'fill-opacity', 0.625, polyfillRect, nativeRect);
-  at(3000, 'fill-opacity', 1, polyfillRect, nativeRect);
+  at(2500, 'fill-opacity', [0.625, undefined], polyfillRect, nativeRect);
+  at(3000, 'fill-opacity', [1, undefined], polyfillRect, nativeRect);
 }, 'animate width and opacity');

--- a/test/testcases/animate.html
+++ b/test/testcases/animate.html
@@ -15,7 +15,7 @@
 
   <rect id="nativeRect" x="0" y="100" width="100" height="100" fill="green">
     <nativeAnimate attributeName="width" from="200" to="0" dur="2s" repeatCount="indefinite"/>
-    <animate attributeName="fill-opacity" values="1.75;0.25;1.75" dur="4s" fill="freeze"/>
+    <nativeAnimate attributeName="fill-opacity" values="1.75;0.25;1.75" dur="4s" fill="freeze"/>
   </rect>
 </svg>
 

--- a/test/testcases/begin-end-element-check.js
+++ b/test/testcases/begin-end-element-check.js
@@ -22,19 +22,20 @@ timing_test(function() {
   var polyfillSecondRect = document.getElementById('polyfillSecondRect');
   var nativeSecondRect = document.getElementById('nativeSecondRect');
 
+  at(1000, 'width', 100, polyfillFirstRect, nativeFirstRect);
   executeAt(1000, beginElements);
   at(2000, 'transform', undefined, polyfillSecondRect, nativeSecondRect);
-  at(3000, 'transform', 'translate(-20, 120)',
+  at(3000, 'transform', ['translate(-20, 120)', 'translate(-20 120)'],
       polyfillFirstRect, nativeFirstRect);
-  at(5000, 'transform', 'translate(-40, 90)',
+  at(5000, 'transform', ['translate(-40, 90)', 'translate(-40 90)'],
       polyfillFirstRect, nativeFirstRect);
-  at(6000, 'transform', 'translate(10, -160)',
+  at(6000, 'transform', ['translate(10, -160)', 'translate(10 -160)'],
       polyfillSecondRect, nativeSecondRect);
   executeAt(8000, endElements);
-  at(9000, 'transform', 'translate(-20, 120)',
+  at(9000, 'transform', ['translate(-20, 120)', 'translate(-20 120)'],
       polyfillFirstRect, nativeFirstRect);
   at(10000, 'transform', '', polyfillSecondRect, nativeSecondRect);
   at(12000, 'transform', '', polyfillSecondRect, nativeSecondRect);
-  at(13000, 'transform', 'translate(-40, 90)',
+  at(13000, 'transform', ['translate(-40, 90)', 'translate(-40 90)'],
       polyfillFirstRect, nativeFirstRect);
 }, 'beginElement');

--- a/test/testcases/begin-end-element.html
+++ b/test/testcases/begin-end-element.html
@@ -14,8 +14,8 @@
 
       <rect id="nativeFirstRect" x="110" y="10" width="100" height="100" fill="red" opacity="0.5"/>
       <rect id="nativeSecondRect" x="220" y="110" width="100" height="100" fill="red" opacity="0.5"/>
-      <animateTransform id="nativeFirstAnim" xlink:href="#nativeFirstRect" attributeName="transform" type="translate" from="0,150" to="-100,0" dur="10s" begin="indefinite" end="indefinite" fill="freeze"/>
-      <animateTransform id="nativeSecondAnim" xlink:href="#nativeSecondRect" attributeName="transform" type="translate" from="0,-200" to="50" dur="10s" begin="indefinite" end="indefinite"/>
+      <nativeAnimateTransform id="nativeFirstAnim" xlink:href="#nativeFirstRect" attributeName="transform" type="translate" from="0,150" to="-100,0" dur="10s" begin="indefinite" end="indefinite" fill="freeze"/>
+      <nativeAnimateTransform id="nativeSecondAnim" xlink:href="#nativeSecondRect" attributeName="transform" type="translate" from="0,-200" to="50" dur="10s" begin="indefinite" end="indefinite"/>
     </svg>
 
   </body>

--- a/test/testcases/repeat-count-dur.html
+++ b/test/testcases/repeat-count-dur.html
@@ -14,8 +14,8 @@
 
       <rect id="nativeFirstRect" x="110" y="10" width="300" height="100" fill="red" opacity="0.5"/>
       <rect id="nativeSecondRect" x="220" y="110" width="300" height="100" fill="red" opacity="0.5"/>
-      <animate id="nativeFirstAnim" xlink:href="#nativeFirstRect" attributeName="width" from="0" to="200" dur="4s" repeatCount="2.5" repeatDur="8s" min="7s" max="11s"/>
-      <animate id="nativeSecondAnim" xlink:href="#nativeSecondRect" attributeName="width" from="0" to="200" dur="4s" repeatCount="2" repeatDur="10s" min="7s" max="11s"/>
+      <nativeAnimate id="nativeFirstAnim" xlink:href="#nativeFirstRect" attributeName="width" from="0" to="200" dur="4s" repeatCount="2.5" repeatDur="8s" min="7s" max="11s"/>
+      <nativeAnimate id="nativeSecondAnim" xlink:href="#nativeSecondRect" attributeName="width" from="0" to="200" dur="4s" repeatCount="2" repeatDur="10s" min="7s" max="11s"/>
     </svg>
 
   </body>

--- a/test/testcases/repeatDur.html
+++ b/test/testcases/repeatDur.html
@@ -12,7 +12,7 @@
   </rect>
 
   <rect id="nativeRect" x="0" y="0" width="300" height="100" fill="red" opacity="0.5">
-    <animate attributeName="width" from="200" to="0" dur="4s" repeatDur="12s"/>
+    <nativeAnimate attributeName="width" from="200" to="0" dur="4s" repeatDur="12s"/>
   </rect>
 </svg>
 

--- a/test/testcases/use-recursively.html
+++ b/test/testcases/use-recursively.html
@@ -24,7 +24,7 @@
 
   <defs>
     <rect id="nativeRect0" x="150" y="0" width="100" height="100" fill="green">
-      <animate id="nativeAnim0" attributeName="width" from="80" to="0" dur="2s" repeatDur="7s" begin="1s"/>
+      <nativeAnimate id="nativeAnim0" attributeName="width" from="80" to="0" dur="2s" repeatDur="7s" begin="1s"/>
     </rect>
   </defs>
 


### PR DESCRIPTION
Correct some copy/paste errors where the animate tag was used twice instead of
using animate and then nativeAnimate.
